### PR TITLE
fix testDrakeVisualizer.py to auto exit in testing mode

### DIFF
--- a/src/python/tests/testDrakeVisualizer.py
+++ b/src/python/tests/testDrakeVisualizer.py
@@ -1,3 +1,4 @@
+from ddapp import consoleapp
 from ddapp import drakevisualizer
 
 def main():
@@ -7,7 +8,7 @@ def main():
 
     app = drakevisualizer.DrakeVisualizerApp()
     app.mainWindow.show()
-    app.start()
+    consoleapp.ConsoleApp.start()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
need to use ConsoleApp.start() to get the testing mode behavior that
automatically triggers an exit after the application starts when the
--testing flag is given.