### PR TITLE
Sync hand joints (more general)

### DIFF
--- a/src/python/ddapp/startup.py
+++ b/src/python/ddapp/startup.py
@@ -362,14 +362,14 @@ if usePlanning:
 
     handJoints = []
     if drcargs.args().directorConfigFile.find('atlas') != -1:
-        handJoints = roboturdf.getRobotiqJoints()
+        handJoints = roboturdf.getRobotiqJoints() + ['neck_ay']
     else:
         for handModel in ikPlanner.handModels:
             handJoints += handModel.handModel.model.getJointNames()
         # filter base joints out
         handJoints = [ joint for joint in handJoints if joint.find('base')==-1 ]
 
-    teleopJointPropagator = JointPropagator(robotStateModel, teleopRobotModel, handJoints + ['neck_ay'])
+    teleopJointPropagator = JointPropagator(robotStateModel, teleopRobotModel, handJoints)
     playbackJointPropagator = JointPropagator(robotStateModel, playbackRobotModel, handJoints)
     def doPropagation(model=None):
         if teleopRobotModel.getProperty('Visible'):

--- a/src/python/ddapp/startup.py
+++ b/src/python/ddapp/startup.py
@@ -360,8 +360,17 @@ if usePlanning:
         sendDataRequest(lcmdrc.data_request_t.FUSED_HEIGHT, repeatTime)
 
 
-    teleopJointPropagator = JointPropagator(robotStateModel, teleopRobotModel, roboturdf.getRobotiqJoints() + ['neck_ay'])
-    playbackJointPropagator = JointPropagator(robotStateModel, playbackRobotModel, roboturdf.getRobotiqJoints())
+    handJoints = []
+    if drcargs.args().directorConfigFile.find('atlas') != -1:
+        handJoints = roboturdf.getRobotiqJoints()
+    else:
+        for handModel in ikPlanner.handModels:
+            handJoints += handModel.handModel.model.getJointNames()
+        # filter base joints out
+        handJoints = [ joint for joint in handJoints if joint.find('base')==-1 ]
+
+    teleopJointPropagator = JointPropagator(robotStateModel, teleopRobotModel, handJoints + ['neck_ay'])
+    playbackJointPropagator = JointPropagator(robotStateModel, playbackRobotModel, handJoints)
     def doPropagation(model=None):
         if teleopRobotModel.getProperty('Visible'):
             teleopJointPropagator.doPropagation()


### PR DESCRIPTION
Made syncing of hand joints more general. It checks whether the robot is any kind of Atlas and then keeps the old way (getRobotiqJoints) as it's underactuated and wouldnt return all hand joints from the hand model (getRobotiqJoints returns 1, 2, middle for each). Otherwise uses (all of) the hand model(s) to arrive at the hand joints, then filters out the base joints. 

I've compiled and started this up with v5, lwr, and val2. Then verified that ``teleopJointPropagator.jointIndices`` has indices. This is the case for v5 and lwr, and hence should work. Valkyrie doesnt seem to have hand models / factories defined yet.

cc @patmarion @mauricefallon 