### PR TITLE
turn valve in a human manner

### DIFF
--- a/src/python/ddapp/roboturdf.py
+++ b/src/python/ddapp/roboturdf.py
@@ -30,6 +30,7 @@ with open(drcargs.args().directorConfigFile) as directorConfigFile:
     handCombinations = directorConfig['handCombinations']
     numberOfHands = len(handCombinations)
 
+    headLink = directorConfig['headLink']
 
 
 def getRobotGrayColor():
@@ -112,6 +113,9 @@ class RobotModelItem(om.ObjectModelItem):
             return t
         else:
             return None
+
+    def getHeadLink(self):
+        return headLink
 
     def getLinkContactPoints(self, linkName):
         pts = self.model.getBodyContactPoints(linkName)

--- a/src/python/ddapp/segmentationroutines.py
+++ b/src/python/ddapp/segmentationroutines.py
@@ -106,14 +106,14 @@ class RobotModelViewProvider(object):
         self.model = model
 
     def getViewFrame(self):
-        return self.model.getLinkFrame('head')
+        return self.model.getLinkFrame(self.model.getHeadLink())
 
     def getViewOrigin(self):
-        headFrame = self.model.getLinkFrame('head')
+        headFrame = self.model.getLinkFrame(self.model.getHeadLink())
         return np.array(headFrame.GetPosition())
 
     def getViewDirection(self):
-        headFrame = self.model.getLinkFrame('head')
+        headFrame = self.model.getLinkFrame(self.model.getHeadLink())
         viewDirection = [1,0,0]
         headFrame.TransformVector(viewDirection, viewDirection)
         return np.array(viewDirection)

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -170,21 +170,11 @@ class TableDemo(object):
 
         self.tableData = tableData
 
-        self.tableBox = vis.showPolyData(tableData.box, 'table box', parent=aff, color=[0,1,0], visible=False)
-        #self.tableObj.actor.SetUserTransform(self.tableFrame.transform)
-        self.tableBox.actor.SetUserTransform(tableData.frame)
-
+        tableBox = vis.showPolyData(tableData.box, 'table box', parent=aff, color=[0,1,0], visible=False)
+        tableBox.actor.SetUserTransform(tableData.frame)
 
         if self.useCollisionEnvironment:
             self.addCollisionObject(aff)
-
-        return
-
-        self.tableObj = vis.showPolyData(tableData.mesh, 'table', parent='affordances', color=[0,1,0])
-        self.tableFrame = vis.showFrame(tableData.frame, 'table frame', parent=self.tableObj, scale=0.2)
-        self.tableBox = vis.showPolyData(tableData.box, 'table box', parent=self.tableObj, color=[0,1,0], visible=False)
-        self.tableObj.actor.SetUserTransform(self.tableFrame.transform)
-        self.tableBox.actor.SetUserTransform(self.tableFrame.transform)
 
 
     def onSegmentBin(self, p1, p2):

--- a/src/python/ddapp/valvedemo.py
+++ b/src/python/ddapp/valvedemo.py
@@ -112,8 +112,13 @@ class ValvePlannerDemo(object):
         self.smallValve = True
 
     def setupStance(self):
-        self.relativeStanceXYZInitial = [-0.9, -0.3, 0.0]
-        self.relativeStanceRPYInitial = [0, 0, 0]
+        if (self.turningMode==0): # simple
+            self.relativeStanceXYZInitial = [-0.9, -0.3, 0.0]
+            self.relativeStanceRPYInitial = [0, 0, 0]
+        else: # human-like
+            self.relativeStanceXYZInitial = [-0.5, 0.0, 0.0]
+            self.relativeStanceRPYInitial = [0, 0, 0]
+
         self.relativeStanceXYZ = self.relativeStanceXYZInitial
         self.relativeStanceRPY = self.relativeStanceRPYInitial
 

--- a/src/python/ddapp/valvedemo.py
+++ b/src/python/ddapp/valvedemo.py
@@ -261,7 +261,7 @@ class ValvePlannerDemo(object):
         return graspFrame
 
     def spawnValveAffordance(self):
-        radius = 0.10
+        radius = 0.20
         tubeRadius = 0.02
         position = [0, 0, 1.2]
         rpy = [0, 0, 0]

--- a/src/python/ddapp/viewbehaviors.py
+++ b/src/python/ddapp/viewbehaviors.py
@@ -541,10 +541,10 @@ def showRightClickMenu(displayPoint, view):
         rgb = colorsys.hls_to_rgb(lastRandomColor, 0.7, 1.0)
         obj = vis.showPolyData(polyData, pointCloudObj.getProperty('Name') + ' copy', color=rgb, parent='point clouds')
 
-        t = vtk.vtkTransform()
-        t.PostMultiply()
-        t.Translate(filterUtils.computeCentroid(polyData))
-        segmentation.makeMovable(obj, t)
+        #t = vtk.vtkTransform()
+        #t.PostMultiply()
+        #t.Translate(filterUtils.computeCentroid(polyData))
+        #segmentation.makeMovable(obj, t)
         om.setActiveObject(obj)
         pickedObj.setProperty('Visible', False)
 


### PR DESCRIPTION
Supports human-like valve turning:
* defaults to original finals-style turning but can use human style turning
* verified that both modes work with atlas v5 in the mit simulator
* demo with val in scs:
https://www.dropbox.com/s/fkyw1t70dfoyttd/valve_turning_with_val.ogv?dl=0

Other:
* disabled the point cloud re-centering (from greg)
* fixed a hard coded 'head' string
