### PR TITLE
add generic pointcloud rendering

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -175,21 +175,15 @@ if (USE_DRC)
   set(moc_srcs)
   qt4_wrap_cpp(moc_srcs
     ddBotImageQueue.h
+    ddKinectLCM.h
+    ddPointCloudLCM.h
   )
 
   list(APPEND srcs
     ${moc_srcs}
     ddBotImageQueue.cpp
-  )
-
-  set(moc_srcs)
-  qt4_wrap_cpp(moc_srcs
-    ddKinectLCM.h
-  )
-
-  list(APPEND srcs
-    ${moc_srcs}
     ddKinectLCM.cpp
+    ddPointCloudLCM.cpp
   )
 
   list(APPEND wrap_files

--- a/src/app/ddPointCloudLCM.cpp
+++ b/src/app/ddPointCloudLCM.cpp
@@ -1,0 +1,160 @@
+#include <boost/thread.hpp>
+
+#include "ddPointCloudLCM.h"
+
+#include <vtkIdTypeArray.h>
+#include <vtkCellArray.h>
+#include <vtkNew.h>
+
+#include <multisense_utils/conversions_lcm.hpp>
+
+namespace pcl
+{
+  // Euclidean Velodyne coordinate, including intensity and ring number. 
+  struct PointXYZIR
+  {
+    PCL_ADD_POINT4D;                    // quad-word XYZ
+    float    intensity;                 ///< laser intensity reading
+    uint16_t ring;                      ///< laser ring number
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW     // ensure proper alignment
+  } EIGEN_ALIGN16;
+
+};
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(pcl::PointXYZIR,
+                                  (float, x, x)
+                                  (float, y, y)
+                                  (float, z, z)
+                                  (float, intensity, intensity)
+                                  (uint16_t, ring, ring))
+
+
+//-----------------------------------------------------------------------------
+ddPointCloudLCM::ddPointCloudLCM(QObject* parent) : QObject(parent)
+{
+  mPolyData = vtkSmartPointer<vtkPolyData>::New();
+}
+
+
+//-----------------------------------------------------------------------------
+void ddPointCloudLCM::init(ddLCMThread* lcmThread, const QString& botConfigFile)
+{
+  
+  mLCM = lcmThread;
+  
+  QString channelName = "VELODYNE";
+  ddLCMSubscriber* subscriber = new ddLCMSubscriber(channelName, this);
+
+  this->connect(subscriber, SIGNAL(messageReceived(const QByteArray&, const QString&)),
+          SLOT(onPointCloudFrame(const QByteArray&, const QString&)), Qt::DirectConnection);
+
+  mLCM->addSubscriber(subscriber);
+
+}
+
+
+
+namespace {
+
+
+
+//----------------------------------------------------------------------------
+vtkSmartPointer<vtkCellArray> NewVertexCells(vtkIdType numberOfVerts)
+{
+  vtkNew<vtkIdTypeArray> cells;
+  cells->SetNumberOfValues(numberOfVerts*2);
+  vtkIdType* ids = cells->GetPointer(0);
+  for (vtkIdType i = 0; i < numberOfVerts; ++i)
+    {
+    ids[i*2] = 1;
+    ids[i*2+1] = i;
+    }
+
+  vtkSmartPointer<vtkCellArray> cellArray = vtkSmartPointer<vtkCellArray>::New();
+  cellArray->SetCells(numberOfVerts, cells.GetPointer());
+  return cellArray;
+}
+
+
+
+//----------------------------------------------------------------------------
+vtkSmartPointer<vtkPolyData> PolyDataFromPointCloud(pcl::PointCloud<pcl::PointXYZIR>::ConstPtr cloud)
+{
+  vtkIdType nr_points = cloud->points.size();
+
+  vtkNew<vtkPoints> points;
+  points->SetDataTypeToFloat();
+  points->SetNumberOfPoints(nr_points);
+
+  vtkNew<vtkFloatArray> intensityArray;
+  intensityArray->SetName("intensity");
+  intensityArray->SetNumberOfComponents(1);
+  intensityArray->SetNumberOfValues(nr_points);
+
+  vtkNew<vtkUnsignedIntArray> ringArray;
+  ringArray->SetName("ring");
+  ringArray->SetNumberOfComponents(1);
+  ringArray->SetNumberOfValues(nr_points);
+
+  vtkIdType j = 0;    
+  for (vtkIdType i = 0; i < nr_points; ++i)
+  {
+    // Check if the point is invalid
+    if (!pcl_isfinite (cloud->points[i].x) ||
+        !pcl_isfinite (cloud->points[i].y) ||
+        !pcl_isfinite (cloud->points[i].z))
+      continue;
+
+    float point[3] = {cloud->points[i].x, cloud->points[i].y, cloud->points[i].z};
+    points->SetPoint(j, point);
+
+    float intensity = cloud->points[i].intensity;
+    intensityArray->SetValue(j,intensity);
+
+    uint16_t ring = cloud->points[i].ring;
+    ringArray->SetValue(j,ring);
+
+    j++;
+  }
+  nr_points = j;
+  points->SetNumberOfPoints(nr_points);
+
+  vtkSmartPointer<vtkPolyData> polyData = vtkSmartPointer<vtkPolyData>::New();
+  polyData->SetPoints(points.GetPointer());
+  polyData->GetPointData()->AddArray(intensityArray.GetPointer());
+  polyData->GetPointData()->AddArray(ringArray.GetPointer());
+  polyData->SetVerts(NewVertexCells(nr_points));
+  return polyData;
+}
+
+
+};
+
+
+
+//-----------------------------------------------------------------------------
+void ddPointCloudLCM::onPointCloudFrame(const QByteArray& data, const QString& channel)
+{
+  
+  drc::pointcloud2_t message;
+  message.decode(data.data(), 0, data.size());
+
+  //convert to pcl object:
+  pcl::PointCloud<pcl::PointXYZIR>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZIR> ());
+  pcl::fromLCMPointCloud2( message, *cloud);
+  vtkSmartPointer<vtkPolyData> polyData = PolyDataFromPointCloud(cloud);
+
+  QMutexLocker locker(&this->mPolyDataMutex);
+  this->mPolyData = polyData;
+  this->mUtime = message.utime;
+}
+
+
+//-----------------------------------------------------------------------------
+qint64 ddPointCloudLCM::getPointCloudFromPointCloud(vtkPolyData* polyDataRender)
+{
+  QMutexLocker locker(&this->mPolyDataMutex);
+  polyDataRender->ShallowCopy(this->mPolyData);
+  return this->mUtime;
+}
+

--- a/src/app/ddPointCloudLCM.h
+++ b/src/app/ddPointCloudLCM.h
@@ -1,0 +1,48 @@
+#ifndef __ddPointCloudLCM_h
+#define __ddPointCloudLCM_h
+
+#include <QObject>
+
+#include "ddLCMThread.h"
+#include "ddLCMSubscriber.h"
+#include "ddAppConfigure.h"
+
+#include <string>
+#include <sstream>
+
+#include <vtkSmartPointer.h>
+#include <vtkPolyData.h>
+#include <vtkPointData.h>
+#include <vtkUnsignedIntArray.h>
+#include <vtkFloatArray.h>
+
+#include <lcm/lcm-cpp.hpp>
+#include <lcmtypes/drc/pointcloud2_t.hpp>
+
+class DD_APP_EXPORT ddPointCloudLCM : public QObject
+{
+  Q_OBJECT
+
+public:
+
+  ddPointCloudLCM(QObject* parent=NULL);
+  
+  void init(ddLCMThread* lcmThread, const QString& botConfigFile);
+  qint64 getPointCloudFromPointCloud(vtkPolyData* polyDataRender);
+
+protected slots:
+
+  void onPointCloudFrame(const QByteArray& data, const QString& channel);
+
+
+protected:
+
+  ddLCMThread* mLCM;
+
+  vtkSmartPointer<vtkPolyData> mPolyData;
+  int64_t mUtime;
+  QMutex mPolyDataMutex;
+
+};
+
+#endif

--- a/src/app/wrapped_methods_drc.txt
+++ b/src/app/wrapped_methods_drc.txt
@@ -20,3 +20,6 @@ QList<double> ddBotImageQueue::unprojectPixel(const QString&, int, int);
 ddKinectLCM::ddKinectLCM(QObject*);
 void ddKinectLCM::init(ddLCMThread*, const QString&);
 qint64 ddKinectLCM::getPointCloudFromKinect(vtkPolyData*)
+ddPointCloudLCM::ddPointCloudLCM(QObject*);
+void ddPointCloudLCM::init(ddLCMThread*, const QString&);
+qint64 ddPointCloudLCM::getPointCloudFromPointCloud(vtkPolyData*)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -75,6 +75,7 @@ set(python_files
   ddapp/pfgrasppanel.py
   ddapp/planplayback.py
   ddapp/playbackpanel.py
+  ddapp/pointcloudlcm.py
   ddapp/pointpicker.py
   ddapp/polarisplatformplanner.py
   ddapp/propertyset.py

--- a/src/python/ddapp/pointcloudlcm.py
+++ b/src/python/ddapp/pointcloudlcm.py
@@ -1,0 +1,148 @@
+import ddapp.applogic as app
+from ddapp import lcmUtils
+from ddapp import transformUtils
+from ddapp import visualization as vis
+from ddapp import filterUtils
+from ddapp import drcargs
+from ddapp.shallowCopy import shallowCopy
+from ddapp.timercallback import TimerCallback
+from ddapp import vtkNumpy
+from ddapp import objectmodel as om
+import ddapp.vtkAll as vtk
+from ddapp.debugVis import DebugData
+
+import PythonQt
+from PythonQt import QtCore, QtGui
+import bot_core as lcmbotcore
+import numpy as np
+from ddapp.simpletimer import SimpleTimer
+from ddapp import ioUtils
+import sys
+import drc as lcmdrc
+from ddapp.consoleapp import ConsoleApp
+
+
+class PointCloudItem(om.ObjectModelItem):
+
+    def __init__(self, model):
+
+        om.ObjectModelItem.__init__(self, 'PointCloud', om.Icons.Eye)
+
+        self.model = model
+        self.scalarBarWidget = None
+        self.addProperty('Color By', 0,
+                         attributes=om.PropertyAttributes(enumNames=['Solid Color']))
+        self.addProperty('Updates Enabled', True)
+        self.addProperty('Framerate', model.targetFps,
+                         attributes=om.PropertyAttributes(decimals=0, minimum=1.0, maximum=30.0, singleStep=1, hidden=False))
+        self.addProperty('Visible', model.visible)
+        
+    def _onPropertyChanged(self, propertySet, propertyName):
+        om.ObjectModelItem._onPropertyChanged(self, propertySet, propertyName)
+
+        if propertyName == 'Updates Enabled':
+            if self.getProperty('Updates Enabled'):
+                self.model.start()
+            else:
+                self.model.stop()
+
+        elif propertyName == 'Visible':
+            self.model.setVisible(self.getProperty(propertyName))
+
+        elif propertyName == 'Framerate':
+            self.model.setFPS(self.getProperty('Framerate'))
+
+        elif propertyName == 'Color By':
+            self._updateColorBy()
+
+        self.model.polyDataObj._renderAllViews()
+
+
+    def _updateColorBy(self):
+
+        arrayMap = {
+          0 : 'Solid Color'
+          }
+
+        colorBy = self.getProperty('Color By')
+        arrayName = arrayMap.get(colorBy)
+
+        self.model.polyDataObj.setProperty('Color By', arrayName)
+
+
+
+class PointCloudSource(TimerCallback):
+
+    def __init__(self, view, _PointCloudQueue):
+        self.view = view
+        self.PointCloudQueue = _PointCloudQueue
+
+        self.visible = True
+        
+        self.p = vtk.vtkPolyData()
+        utime = PointCloudQueue.getPointCloudFromPointCloud(self.p)
+        self.polyDataObj = vis.PolyDataItem('pointcloud source', shallowCopy(self.p), view)
+        self.polyDataObj.actor.SetPickable(1)
+        self.polyDataObj.initialized = False
+
+        om.addToObjectModel(self.polyDataObj)
+
+        self.queue = PythonQt.dd.ddBotImageQueue(lcmUtils.getGlobalLCMThread())
+        self.queue.init(lcmUtils.getGlobalLCMThread(), drcargs.args().config_file)
+
+        self.targetFps = 30
+        self.timerCallback = TimerCallback(targetFps=self.targetFps)
+        self.timerCallback.callback = self._updateSource
+        #self.timerCallback.start()
+        
+    def start(self):
+        self.timerCallback.start()
+
+    def stop(self):
+        self.timerCallback.stop()
+
+    def setFPS(self, framerate):
+        self.targetFps = framerate
+        self.timerCallback.stop()
+        self.timerCallback.targetFps = framerate
+        self.timerCallback.start()
+
+    def setVisible(self, visible):
+        self.polyDataObj.setProperty('Visible', visible)
+
+    def _updateSource(self):
+        p = vtk.vtkPolyData()
+        utime = self.PointCloudQueue.getPointCloudFromPointCloud(p)
+
+        if not p.GetNumberOfPoints():
+            return
+
+        sensorToLocalFused = vtk.vtkTransform()
+        self.queue.getTransform('VELODYNE', 'local', utime, sensorToLocalFused)
+        p = filterUtils.transformPolyData(p,sensorToLocalFused)
+        self.polyDataObj.setPolyData(p)
+
+        if not self.polyDataObj.initialized:
+            self.polyDataObj.initialized = True
+
+
+def init(view):
+    global PointCloudQueue, _pointcloudItem, _pointcloudSource
+    PointCloudQueue = PythonQt.dd.ddPointCloudLCM(lcmUtils.getGlobalLCMThread())
+    PointCloudQueue.init(lcmUtils.getGlobalLCMThread(), drcargs.args().config_file)
+    
+    _pointcloudSource = PointCloudSource(view, PointCloudQueue)
+    _pointcloudSource.start()
+
+    sensorsFolder = om.getOrCreateContainer('sensors')
+
+    _pointcloudItem = PointCloudItem(_pointcloudSource)
+    om.addToObjectModel(_pointcloudItem, sensorsFolder)
+    
+
+def startButton():
+    view = app.getCurrentRenderView()
+    init(view)
+    _pointcloudSource.start()
+
+app.addToolbarMacro('start live pointcloud', startButton)


### PR DESCRIPTION
Supports using a generic PCL point cloud as a blob for data transmission in LCM and rendering in the designer

This function mirrors pc/conversions.hpp to convert between the lcmtype and an pcl point cloud:
pcl::fromLCMPointCloud2( message, *cloud);
which is defined in multisense_utils/conversions_lcm.hpp to decompress data

Alsod as a python widget based on the kinect widget.

Velodyne demo:
https://www.dropbox.com/s/ynjgj4sywrfb367/velodyne_in_viewer.mp4?dl=0
(Currently works with a specific XYZIR data type)


... drc PR to follow