### PR TITLE
Updates to tabledemo and shared autonomy

### DIFF
--- a/src/app/ddMainWindow.ui
+++ b/src/app/ddMainWindow.ui
@@ -573,7 +573,7 @@
     <string>Task Launcher</string>
    </property>
    <property name="shortcut">
-    <string/>
+    <string>F10</string>
    </property>
   </action>
   <action name="ActionPFGraspPanel">

--- a/src/python/ddapp/playbackpanel.py
+++ b/src/python/ddapp/playbackpanel.py
@@ -258,7 +258,7 @@ class PlaybackPanel(object):
 
     def isPlanFeasible(self):
         plan = robotstate.asRobotPlan(self.plan)
-        return plan is not None and max(plan.plan_info) < 10
+        return plan is not None and max(plan.plan_info) < 10 and min(plan.plan_info) >= 0:
 
     def getPlanInfo(self, plan):
         plan = robotstate.asRobotPlan(self.plan)

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -71,6 +71,7 @@ class TableDemo(object):
         self.requiredUserPromptEnabled = True
 
         self.plans = []
+        self.clusterObjects = []
         self.frameSyncs = {}
 
         self.graspingHand = 'left' # left, right, both

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1300,3 +1300,7 @@ class TableTaskPanel(TaskUserPanel):
             addManipulation(functools.partial(v.planDropPostureLower, v.graspingHand), name='drop: lower arm')
         else:
             addManipulation(functools.partial(v.planPreGrasp, v.graspingHand), name='go home')
+
+        if len(v.clusterObjects) > 0: # There is still sth on the table, let's do it again!
+            self.taskTree.selectTaskByName('reach')
+            self.onContinue()

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1206,7 +1206,7 @@ class TableTaskPanel(TaskUserPanel):
             if confirm:
                 addTask(rt.UserPromptTask(name='Confirm execution has finished', message='Continue when plan finishes.'), parent=parent)
 
-        def addManipulation(func, name, parent=None, confirm=True):
+        def addManipulation(func, name, parent=None, confirm=False):
             group = self.taskTree.addGroup(name, parent=parent)
             addFunc(func, name='plan motion', parent=group)
             addTask(rt.CheckPlanInfo(name='check manip plan info'), parent=group)

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1200,7 +1200,8 @@ class TableTaskPanel(TaskUserPanel):
         if len(self.tableDemo.clusterObjects) > 0: # There is still sth on the table, let's do it again!
             print "There are more objects on the table, going at it again!"
             self.taskTree.selectTaskByName('reach')
-            #self.onContinue()
+            self.onPause()
+            self.onContinue()
         else:
             print "Table clear, sir!"
 

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -291,7 +291,8 @@ class TableDemo(object):
         if self.useCollisionEnvironment:
             self.prepCollisionEnvironment()
             collisionObj = om.findObjectByName(obj.getProperty('Name') + ' affordance')
-            collisionObj.setProperty('Collision Enabled', False)
+            if not self.ikPlanner.fixedBaseArm:
+                collisionObj.setProperty('Collision Enabled', False)
 
         return obj, frameObj
 

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1196,6 +1196,14 @@ class TableTaskPanel(TaskUserPanel):
         elif propertyName == 'Scene':
             self.tableDemo.sceneID = self.params.getProperty('Scene')
 
+    def pickupMoreObjects(self):
+        if len(self.tableDemo.clusterObjects) > 0: # There is still sth on the table, let's do it again!
+            print "There are more objects on the table, going at it again!"
+            self.taskTree.selectTaskByName('reach')
+            #self.onContinue()
+        else:
+            print "Table clear, sir!"
+
     def addTasks(self):
 
         # some helpers
@@ -1307,6 +1315,4 @@ class TableTaskPanel(TaskUserPanel):
         else:
             addManipulation(functools.partial(v.planPreGrasp, v.graspingHand), name='go home')
 
-        if len(v.clusterObjects) > 0: # There is still sth on the table, let's do it again!
-            self.taskTree.selectTaskByName('reach')
-            self.onContinue()
+        addFunc(self.pickupMoreObjects, 'clear until table empty', parent='clear until table empty folder')

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1302,7 +1302,7 @@ class TableTaskPanel(TaskUserPanel):
             addTask(rt.WaitForWalkExecution(name='wait for walking'), parent=walkToBin)
 
         # drop in bin
-        if v.ikPlanner.fixedBaseArm: # v.ikPlanner.pushToMatlab: # latter statement doesnt work since not yet set when initialising
+        if not v.ikPlanner.fixedBaseArm: # v.ikPlanner.pushToMatlab: # latter statement doesnt work since not yet set when initialising
             addManipulation(functools.partial(v.planDropPostureRaise, v.graspingHand), name='drop: raise arm') # seems to ignore arm side?
         else: # multi-posture goal not working in EXOTica
             addManipulation(functools.partial(v.planPreGrasp, v.graspingHand), name='drop: pre-raise arm')

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1293,9 +1293,14 @@ class TableTaskPanel(TaskUserPanel):
             addTask(rt.WaitForWalkExecution(name='wait for walking'), parent=walkToBin)
 
         # drop in bin
-        addManipulation(functools.partial(v.planDropPostureRaise, v.graspingHand), name='drop: raise arm') # seems to ignore arm side?
+        if v.ikPlanner.fixedBaseArm: # v.ikPlanner.pushToMatlab: # latter statement doesnt work since not yet set when initialising
+            addManipulation(functools.partial(v.planDropPostureRaise, v.graspingHand), name='drop: raise arm') # seems to ignore arm side?
+        else: # multi-posture goal not working in EXOTica
+            addManipulation(functools.partial(v.planPreGrasp, v.graspingHand), name='drop: pre-raise arm')
+            addManipulation(functools.partial(v.planPostureFromDatabase, 'table clearing', 'pre drop 1', side=v.graspingHand), 'drop: raise arm')
+            addManipulation(functools.partial(v.planPostureFromDatabase, 'table clearing', 'pre drop 2', side=v.graspingHand), 'drop: lower arm')
         addFunc(functools.partial(v.dropTableObject, side=v.graspingHand), 'drop', parent='drop: release', confirm=True)
-        addManipulation(functools.partial(v.planDropPostureLower, v.graspingHand), name='drop: lower arm')
+
         if not v.ikPlanner.fixedBaseArm:
             addManipulation(functools.partial(v.planDropPostureLower, v.graspingHand), name='drop: lower arm')
         else:

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1296,3 +1296,7 @@ class TableTaskPanel(TaskUserPanel):
         addManipulation(functools.partial(v.planDropPostureRaise, v.graspingHand), name='drop: raise arm') # seems to ignore arm side?
         addFunc(functools.partial(v.dropTableObject, side=v.graspingHand), 'drop', parent='drop: release', confirm=True)
         addManipulation(functools.partial(v.planDropPostureLower, v.graspingHand), name='drop: lower arm')
+        if not v.ikPlanner.fixedBaseArm:
+            addManipulation(functools.partial(v.planDropPostureLower, v.graspingHand), name='drop: lower arm')
+        else:
+            addManipulation(functools.partial(v.planPreGrasp, v.graspingHand), name='go home')

--- a/src/python/ddapp/tasks/robottasks.py
+++ b/src/python/ddapp/tasks/robottasks.py
@@ -178,7 +178,7 @@ class CheckPlanInfo(UserPromptTask):
         properties.setProperty('Message', 'Plan is invalid. Do you want to accept it anyway?')
 
     def run(self):
-        if robotSystem.ikPlanner.lastManipPlan and max(robotSystem.ikPlanner.lastManipPlan.plan_info) <= 10:
+        if robotSystem.ikPlanner.lastManipPlan and max(robotSystem.ikPlanner.lastManipPlan.plan_info) <= 10 and min(robotSystem.ikPlanner.lastManipPlan.plan_info) >= 0:
             return
         else:
             return UserPromptTask.run(self)

--- a/src/python/ddapp/tasks/taskmanagerwidget.py
+++ b/src/python/ddapp/tasks/taskmanagerwidget.py
@@ -2,7 +2,6 @@ from ddapp.tasks.robottasks import *
 from ddapp.tasks.descriptions import loadTaskDescription
 import ddapp.applogic as app
 
-
 def _splitCamelCase(name):
     name = re.sub('(.)([A-Z][a-z]+)', r'\1 \2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1 \2', name)
@@ -156,8 +155,18 @@ class TaskTree(object):
             if isinstance(obj, TaskItem) and obj.task == task:
                 return obj
 
+    def findTaskItemByName(self, name):
+        for obj in self.objectModel.getObjects():
+            if isinstance(obj, om.ContainerItem) and obj.getProperty('Name') == name:
+                return obj.children()[0]
+
     def selectTask(self, task):
         obj = self.findTaskItem(task)
+        if obj:
+            self.objectModel.setActiveObject(obj)
+
+    def selectTaskByName(self, name):
+        obj = self.findTaskItemByName(name)
         if obj:
             self.objectModel.setActiveObject(obj)
 

--- a/src/python/ddapp/valvedemo.py
+++ b/src/python/ddapp/valvedemo.py
@@ -558,7 +558,7 @@ class ValvePlannerDemo(object):
 
         plan = self.ikPlanner.runIkTraj(constraints, startPoseName, endPoseName, self.nominalPoseName, ikParameters=ikParameters)
 
-        if resetPoses and not retract and max(plan.plan_info) <= 10:
+        if resetPoses and not retract and max(plan.plan_info) <= 10 and min(plan.plan_info) >= 0:
             self.setReachAndTouchPoses(plan)
 
         return plan


### PR DESCRIPTION
- **Added shortcut F10 to open the task panel**, similar to F8, F9, and Ctrl+B - since we're finding ourselves opening the task panel a lot. Happy to change to another key, but F10 came in handy after F8, F9
- **Methods to jump in the task tree and continue** - in tabledemo used to repeat the spiel until there are no more objects that have been segmented (clusterObjects is empty). If there's a better way than pausing and continuing, please let me know :)
- **Fix for EXOTica planning when checking manip plan info**: EXOTica mirrors the 0 plan info for successful requests and 13 when constraints are not satisfied, but we also have negative return codes (this shouldn't conflict with Matlab planning - does it?)
- Minor changes that are flagged with the fixed base switch
