### PR TITLE
Use hand grasping status in tabledemo (no more human acknowledgement required)

### DIFF
--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1306,7 +1306,8 @@ class TableTaskPanel(TaskUserPanel):
         else: # Collision Free - Marco et al.
             addManipulation(functools.partial(v.planReachToTableObjectCollisionFree, v.graspingHand), name='reach')
 
-        addFunc(functools.partial(v.graspTableObject, side=v.graspingHand), 'grasp', parent='reach', confirm=True)
+        addGrasping('close', name='close grasp hand', parent=None, confirm=False)
+        addFunc(functools.partial(v.graspTableObject, side=v.graspingHand), 'sync grasp', parent='reach', confirm=True)
 
         addManipulation(functools.partial(v.planLiftTableObject, v.graspingHand), name='lift object')
 

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -258,9 +258,6 @@ class TableDemo(object):
         if self.useCollisionEnvironment:
             self.affordanceUpdater.graspAffordance(objAffordance.getProperty('Name'), side)
 
-        if self.ikPlanner.fixedBaseArm: # if we're dealing with the real world, close hand
-            self.closeHand(side)
-            return self.delay(5) # wait for three seconds to allow for hand to close
 
     def dropTableObject(self, side='left'):
 

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1242,7 +1242,7 @@ class TableTaskPanel(TaskUserPanel):
             group = self.taskTree.addGroup(name, parent=parent)
             side = self.params.getPropertyEnumValue('Hand')
 
-            checkStatus = False  # whether to check that there is an object in gripper
+            checkStatus = False  # whether to confirm that there is an object in the hand when closed
             if 'userConfig' in drcargs.getDirectorConfig() and 'useKuka' in drcargs.getDirectorConfig()['userConfig']:
                 checkStatus = True
 
@@ -1274,7 +1274,7 @@ class TableTaskPanel(TaskUserPanel):
         # prep
         prep = self.taskTree.addGroup('Preparation')
         if v.ikPlanner.fixedBaseArm:
-            addTask(rt.OpenHand(name='open hand', side=side), parent=prep)
+            addGrasping('open', name='open hand', parent=prep, confirm=False)
             if v.useDevelopment:
                 addFunc(v.prepKukaTestDemoSequence, 'prep from file', parent=prep)
             else:
@@ -1282,6 +1282,7 @@ class TableTaskPanel(TaskUserPanel):
                 addFunc(v.prepGetSceneFrame, 'capture scene frame', parent=prep)
                 addFunc(v.prepKukaLabScene, 'prep kuka lab scene', parent=prep)
         else:
+            # TODO(tbd): replace with addGrasping()
             addTask(rt.CloseHand(name='close grasp hand', side=side), parent=prep)
             addTask(rt.CloseHand(name='close left hand', side='Left'), parent=prep)
             addTask(rt.CloseHand(name='close right hand', side='Right'), parent=prep)

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1133,6 +1133,8 @@ class TableTaskPanel(TaskUserPanel):
         self.addManualButton('Read SDF & Sim', self.tableDemo.loadSDFFileAndRunSim)
 
     def addDefaultProperties(self):
+        # TODO: if there is a way not to display a property where there is only one value, that'd be great
+
         if len(drcargs.getDirectorConfig()['handCombinations']) > 1:  # more than one hand
             self.params.addProperty('Hand', 0,
                                 attributes=om.PropertyAttributes(enumNames=['Left', 'Right']))
@@ -1244,7 +1246,7 @@ class TableTaskPanel(TaskUserPanel):
                 checkStatus = True
 
             if mode == 'open':
-                addTask(rt.OpenHand(name='open grasp hand', side=side), parent=group)
+                addTask(rt.OpenHand(name='open grasp hand', side=side, CheckStatus=checkStatus), parent=group)
             else:
                 addTask(rt.CloseHand(name='close grasp hand', side=side, CheckStatus=checkStatus), parent=group)
             if confirm:
@@ -1266,7 +1268,7 @@ class TableTaskPanel(TaskUserPanel):
         if v.ikPlanner.fixedBaseArm:
             if not v.useDevelopment:
                 addManipulation(functools.partial(v.planPostureFromDatabase, 'roomMapping', 'p3_down', side='left'), 'go to pre-mapping pose')
-        # TODO: mapping
+        # TODO(wxm): mapping
 
         # prep
         prep = self.taskTree.addGroup('Preparation')

--- a/src/python/ddapp/tabledemo.py
+++ b/src/python/ddapp/tabledemo.py
@@ -1237,6 +1237,24 @@ class TableTaskPanel(TaskUserPanel):
                 addTask(rt.UserPromptTask(name='Confirm execution has finished', message='Continue when plan finishes.'),
                         parent=group)
 
+        def addGrasping(mode, name, parent=None, confirm=False):
+            assert mode in ('open', 'close')
+            group = self.taskTree.addGroup(name, parent=parent)
+            side = self.params.getPropertyEnumValue('Hand')
+
+            checkStatus = False  # whether to check that there is an object in gripper
+            if 'userConfig' in drcargs.getDirectorConfig() and 'useKuka' in drcargs.getDirectorConfig()['userConfig']:
+                checkStatus = True
+
+            if mode == 'open':
+                addTask(rt.OpenHand(name='open grasp hand', side=side), parent=group)
+            else:
+                addTask(rt.CloseHand(name='close grasp hand', side=side, CheckStatus=checkStatus), parent=group)
+            if confirm:
+                addTask(rt.UserPromptTask(name='Confirm grasping has succeeded', message='Continue when grasp finishes.'),
+                        parent=group)
+
+
         v = self.tableDemo
 
         self.taskTree.removeAllTasks()

--- a/src/python/ddapp/tasks/robottasks.py
+++ b/src/python/ddapp/tasks/robottasks.py
@@ -711,7 +711,7 @@ class CloseHand(AsyncTask):
         if self.properties.getProperty('Check status'):
             responseChannel = 'GRASPING_STATE'
             responseMessageClass = lcmdrc.boolean_t
-            grasping_state = lcmUtils.MessageResponseHelper(responseChannel, responseMessageClass).waitForResponse(timeout=5000)
+            grasping_state = lcmUtils.MessageResponseHelper(responseChannel, responseMessageClass).waitForResponse(timeout=7000)
             if grasping_state is not None and grasping_state.data == 1:
                 self.statusMessage = "Grasping successful"
             else:
@@ -725,6 +725,7 @@ class OpenHand(AsyncTask):
         properties.addProperty('Side', 0, attributes=om.PropertyAttributes(enumNames=['Left', 'Right']))
         properties.addProperty('Mode', 0, attributes=om.PropertyAttributes(enumNames=['Basic', 'Pinch']))
         properties.addProperty('Amount', 100, attributes=propertyset.PropertyAttributes(minimum=0, maximum=100))
+        properties.addProperty('Check status', False)
 
     def getHandDriver(self, side):
         assert side in ('left', 'right')
@@ -734,6 +735,16 @@ class OpenHand(AsyncTask):
         side = self.properties.getPropertyEnumValue('Side').lower()
         self.getHandDriver(side).sendOpen()
         self.getHandDriver(side).sendCustom(100-self.properties.getProperty('Amount'), 100, 100, self.properties.getProperty('Mode'))
+
+        if self.properties.getProperty('Check status'):
+            responseChannel = 'GRASPING_STATE'
+            responseMessageClass = lcmdrc.boolean_t
+            grasping_state = lcmUtils.MessageResponseHelper(responseChannel, responseMessageClass).waitForResponse(timeout=7000)
+            print grasping_state
+            if grasping_state is not None and grasping_state.data == 0:
+                self.statusMessage = "Hand opening successful"
+            else:
+                self.fail("Could not open hand")
 
 
 class CommitFootstepPlan(AsyncTask):

--- a/src/python/ddapp/tasks/robottasks.py
+++ b/src/python/ddapp/tasks/robottasks.py
@@ -698,7 +698,7 @@ class CloseHand(AsyncTask):
         properties.addProperty('Side', 0, attributes=om.PropertyAttributes(enumNames=['Left', 'Right']))
         properties.addProperty('Mode', 0, attributes=om.PropertyAttributes(enumNames=['Basic', 'Pinch']))
         properties.addProperty('Amount', 100, attributes=propertyset.PropertyAttributes(minimum=0, maximum=100))
-        properties.addProperty('Check Status', False)
+        properties.addProperty('Check status', False)
 
     def getHandDriver(self, side):
         assert side in ('left', 'right')
@@ -708,7 +708,7 @@ class CloseHand(AsyncTask):
         side = self.properties.getPropertyEnumValue('Side').lower()
         self.getHandDriver(side).sendCustom(self.properties.getProperty('Amount'), 100, 100, self.properties.getProperty('Mode'))
 
-        if self.properties.getProperty('Check Status'):
+        if self.properties.getProperty('Check status'):
             responseChannel = 'GRASPING_STATE'
             responseMessageClass = lcmdrc.boolean_t
             grasping_state = lcmUtils.MessageResponseHelper(responseChannel, responseMessageClass).waitForResponse(timeout=5000)

--- a/src/python/ddapp/tasks/robottasks.py
+++ b/src/python/ddapp/tasks/robottasks.py
@@ -737,14 +737,24 @@ class OpenHand(AsyncTask):
         self.getHandDriver(side).sendCustom(100-self.properties.getProperty('Amount'), 100, 100, self.properties.getProperty('Mode'))
 
         if self.properties.getProperty('Check status'):
-            responseChannel = 'GRASPING_STATE'
-            responseMessageClass = lcmdrc.boolean_t
-            grasping_state = lcmUtils.MessageResponseHelper(responseChannel, responseMessageClass).waitForResponse(timeout=7000)
-            print grasping_state
-            if grasping_state is not None and grasping_state.data == 0:
-                self.statusMessage = "Hand opening successful"
-            else:
-                self.fail("Could not open hand")
+            WaitForGraspingState().run()
+
+
+class WaitForGraspingState(AsyncTask):
+
+    @staticmethod
+    def getDefaultProperties(properties):
+        properties.addProperty('Channel name', 'GRASPING_STATE')
+        # TODO: properties for timeout, responseMessageClass, expectedResponse
+
+    def run(self):
+        responseMessageClass = lcmdrc.boolean_t
+        grasping_state = lcmUtils.MessageResponseHelper(self.properties.getProperty('Channel name'), responseMessageClass).waitForResponse(timeout=7000)
+
+        if grasping_state is not None and grasping_state.data == 0:
+            self.statusMessage = "Hand opening successful"
+        else:
+            self.fail("Could not open hand")
 
 
 class CommitFootstepPlan(AsyncTask):


### PR DESCRIPTION
This series of commits allows to run the tabledemo even more autonomous and recognise whether the hand has grasped something - i.e. it does not require human verification of that the hand is closed and in fact has an item within its fingers.

- Added a new status topic ``GRASPING_STATE`` (boolean_t) that records whether an item has been grasped (``true``) or the hand was successfully opened (``false``)
- Implemented the above as a grasping task in robottasks -- waits (blocking) until a message is received or fails with a timeout (and then blocks further execution of the task tree)
- Added an addGrasping function for this
- Deactivated for humanoids and all others that dont have this message implemented yet
- Changed a few flags to check whether we are dealing with kukas rather than with a standard fixed base