### PR TITLE
clean up the output of the constraintencoder

### DIFF
--- a/src/python/ddapp/ikconstraintencoder.py
+++ b/src/python/ddapp/ikconstraintencoder.py
@@ -11,7 +11,7 @@ import drc as lcmdrc
 import pprint
 import json
 
-class ConstraintEncoder(nje.NumpyEncoder):
+class ConstraintEncoder(nje.NumpyConvertEncoder):
     def default(self, obj):
         if isinstance(obj, vtk.vtkTransform):
             pos, quat = transformUtils.poseFromTransform(obj)
@@ -22,8 +22,7 @@ class ConstraintEncoder(nje.NumpyEncoder):
             for key in obj._fields:
                 d[key] = getattr(obj, key)
             return d
-        return nje.NumpyEncoder.default(self, obj)
-
+        return nje.NumpyConvertEncoder.default(self, obj)
 
 
 def ConstraintDecoder(dct):

--- a/src/python/ddapp/thirdparty/numpyjsoncoder.py
+++ b/src/python/ddapp/thirdparty/numpyjsoncoder.py
@@ -22,6 +22,16 @@ class NumpyEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
+class NumpyConvertEncoder(json.JSONEncoder):
+    def default(self, obj):
+        """
+        if input object is a ndarray it will be converted to a Python list with ndarray.tolist
+        """
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)
+
+
 def NumpyDecoder(dct):
     """
     Decodes a previously encoded numpy ndarray


### PR DESCRIPTION
previously the output string encoding a numpy array was as follows:
     "jointsUpperBound": {"__ndarray__": [0.0, 0.0, 0.0]},

@patmarion : is this a robust away of spotting an np.array and converting it to a list?