### PR TITLE
Update installation pre-requisites when using MacPorts on Mac OS X 10.10.

### DIFF
--- a/distro/pods/drake-distro/install_prereqs.sh
+++ b/distro/pods/drake-distro/install_prereqs.sh
@@ -8,7 +8,9 @@ case $1 in
     brew install python numpy
     brew install vtk5 --with-qt ;;
   ("macports")
-    echo "WARNING: install_prereqs macports not implemented for this module" ;;
+    port install qt4-mac qwt
+    port install python27 py-pip py-numpy
+    port install vtk5 +qt4_mac +python27 ;;
   ("ubuntu")
     apt-get install libqt4-dev libvtk5-dev libvtk5-qt4-dev python-vtk python-numpy ;;
   ("cygwin")


### PR DESCRIPTION
This commit updates the install_prereqs.sh script to install vtk5
using MacPorts-2.3.4, on Mac OS X 10.10.

Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>