### PR TITLE
Fix drc-testing-data filename

### DIFF
--- a/src/python/ddapp/valvedemo.py
+++ b/src/python/ddapp/valvedemo.py
@@ -861,7 +861,7 @@ class ValvePlannerDemo(object):
 
 
     def prepFromFile(self, moveRobot=True):
-        filename = os.path.expanduser('~/drc-testing-data/valve/valve-pod-wall-ihmc-new.vtp')
+        filename = os.path.expanduser('~/drc-testing-data/valve/valve-pod-wall-ihmc.vtp')
         polyData = ioUtils.readPolyData( filename )
         vis.showPolyData( polyData,'pointcloud snapshot')
 


### PR DESCRIPTION
@mauricefallon please sign off on this and confirm that this change is okay. We didn't see the ...-new.vtp and since it is working with the ihmc.vtp I changed the filename. If it is not the right move, please add the -new.vtp file to drc-testing-data -- thanks!