### PR TITLE
Make Matlab commands log file user specific

### DIFF
--- a/src/python/ddapp/matlab.py
+++ b/src/python/ddapp/matlab.py
@@ -147,8 +147,8 @@ class MatlabCommunicator(object):
 
     def getLogFile(self):
         if self.logFile is None:
-            if not os.path.exists(os.path.expanduser('~/.drake-designer')):
-                os.makedirs(os.path.expanduser('~/.drake-designer'))
+            if not os.path.exists(os.path.dirname(self.logFileName)):
+                os.makedirs(os.path.dirname(self.logFileName))
 
             self.logFile = open(self.logFileName, 'w')
         return self.logFile

--- a/src/python/ddapp/matlab.py
+++ b/src/python/ddapp/matlab.py
@@ -134,7 +134,7 @@ class MatlabCommunicator(object):
         self.echoCommandsToStdOut = False
         self.writeCommandsToLogFile = False
         self.logFile = None
-        self.logFileName = '/tmp/matlab_commands.m'
+        self.logFileName = os.path.expanduser('~/.drake-designer/matlab_commands.m')
         self.clearResult()
 
     def checkForResult(self):
@@ -147,6 +147,9 @@ class MatlabCommunicator(object):
 
     def getLogFile(self):
         if self.logFile is None:
+            if not os.path.exists(os.path.expanduser('~/.drake-designer')):
+                os.makedirs(os.path.expanduser('~/.drake-designer'))
+
             self.logFile = open(self.logFileName, 'w')
         return self.logFile
 


### PR DESCRIPTION
Changes the path from ``/tmp/matlab_commands.m`` to ``~/.drake-designer/matlab_commands.m``. It is hence user-specific and there won't be conflicts if drake-designer is used in multiple user accounts on the same machine without restarting.

Addresses https://github.com/openhumanoids/main-distro/issues/2177