### PR TITLE
Fix for #111 - make URDF colors usable again

### DIFF
--- a/src/python/ddapp/robotsystem.py
+++ b/src/python/ddapp/robotsystem.py
@@ -69,12 +69,19 @@ class RobotSystem(object):
         directorConfig = self.getDirectorConfig()
         neckPitchJoint = 'neck_ay'
 
+        # Determine colorMode, fix for #111
+        colorMode = 'URDF Colors' # URDF colors by default
+        if 'colorMode' in directorConfig:
+            assert directorConfig['colorMode'] in ['URDF Colors', 'Solid Color', 'Texture']
+            colorMode = directorConfig['colorMode']
+
+
         if useAtlasDriver:
             atlasDriver = atlasdriver.init(None)
 
 
         if useRobotState:
-            robotStateModel, robotStateJointController = roboturdf.loadRobotModel('robot state model', view, urdfFile=directorConfig['urdfConfig']['robotState'], parent='sensors', color=roboturdf.getRobotGrayColor(), visible=True)
+            robotStateModel, robotStateJointController = roboturdf.loadRobotModel('robot state model', view, urdfFile=directorConfig['urdfConfig']['robotState'], parent='sensors', color=roboturdf.getRobotGrayColor(), visible=True, colorMode=colorMode)
             robotStateJointController.setPose('EST_ROBOT_STATE', robotStateJointController.getPose('q_nom'))
             roboturdf.startModelPublisherListener([(robotStateModel, robotStateJointController)])
             robotStateJointController.addLCMUpdater('EST_ROBOT_STATE')
@@ -129,8 +136,8 @@ class RobotSystem(object):
 
             #startIkServer()
 
-            playbackRobotModel, playbackJointController = roboturdf.loadRobotModel('playback model', view, urdfFile=directorConfig['urdfConfig']['playback'], parent='planning', color=roboturdf.getRobotBlueColor(), visible=False)
-            teleopRobotModel, teleopJointController = roboturdf.loadRobotModel('teleop model', view, urdfFile=directorConfig['urdfConfig']['teleop'], parent='planning', color=roboturdf.getRobotBlueColor(), visible=False)
+            playbackRobotModel, playbackJointController = roboturdf.loadRobotModel('playback model', view, urdfFile=directorConfig['urdfConfig']['playback'], parent='planning', color=roboturdf.getRobotBlueColor(), visible=False, colorMode=colorMode)
+            teleopRobotModel, teleopJointController = roboturdf.loadRobotModel('teleop model', view, urdfFile=directorConfig['urdfConfig']['teleop'], parent='planning', color=roboturdf.getRobotBlueColor(), visible=False, colorMode=colorMode)
 
             if useAtlasConvexHull:
                 chullRobotModel, chullJointController = roboturdf.loadRobotModel('convex hull atlas', view, urdfFile=urdfConfig['chull'], parent='planning',

--- a/src/python/ddapp/roboturdf.py
+++ b/src/python/ddapp/roboturdf.py
@@ -186,7 +186,7 @@ class RobotModelItem(om.ObjectModelItem):
         view.render()
 
 
-def loadRobotModel(name, view=None, parent='planning', urdfFile=None, color=None, visible=True, colorMode='URDF Colors'):
+def loadRobotModel(name, view=None, parent='planning', urdfFile=None, color=None, visible=True, colorMode='Solid Color'):
 
     if not urdfFile:
         urdfFile = urdfConfig['default']
@@ -206,8 +206,9 @@ def loadRobotModel(name, view=None, parent='planning', urdfFile=None, color=None
     obj.setProperty('Color', color or getRobotGrayColor())
     if colorMode == 'Texture': # fix for #111
         obj.setProperty('Textures', True)
-    elif colorMode == 'URDF Colors':
-        obj.useUrdfColors = True
+    elif colorMode == 'Solid Color':
+        obj.useUrdfColors = False
+        obj._updateModelColor()
 
     if view is not None:
         obj.addToView(view)

--- a/src/python/ddapp/roboturdf.py
+++ b/src/python/ddapp/roboturdf.py
@@ -55,13 +55,13 @@ class RobotModelItem(om.ObjectModelItem):
         self.views = []
         self.model = None
         self.callbacks.addSignal(self.MODEL_CHANGED_SIGNAL)
-        self.useUrdfColors = False
+        self.useUrdfColors = True
 
         self.addProperty('Filename', model.filename())
         self.addProperty('Visible', model.visible())
         self.addProperty('Alpha', model.alpha(),
                          attributes=om.PropertyAttributes(decimals=2, minimum=0, maximum=1.0, singleStep=0.1, hidden=False))
-        self.addProperty('Textures', True)
+        self.addProperty('Textures', False) # False by default, unless in directorConfig - this is a fix for #111
         self.addProperty('Color', model.color())
 
 
@@ -151,6 +151,7 @@ class RobotModelItem(om.ObjectModelItem):
         elif not self.useUrdfColors:
             color = QtGui.QColor(*[c*255 for c in self.getProperty('Color')])
             self.model.setColor(color)
+        # TODO (fix for #111): add getLinkColor iterating over all joints and setting color after fixing ddDrakeModel.cpp
 
     def _setupTextureColors(self):
 
@@ -185,7 +186,7 @@ class RobotModelItem(om.ObjectModelItem):
         view.render()
 
 
-def loadRobotModel(name, view=None, parent='planning', urdfFile=None, color=None, visible=True):
+def loadRobotModel(name, view=None, parent='planning', urdfFile=None, color=None, visible=True, colorMode='URDF Colors'):
 
     if not urdfFile:
         urdfFile = urdfConfig['default']
@@ -203,6 +204,11 @@ def loadRobotModel(name, view=None, parent='planning', urdfFile=None, color=None
     obj.setProperty('Visible', visible)
     obj.setProperty('Name', name)
     obj.setProperty('Color', color or getRobotGrayColor())
+    if colorMode == 'Texture': # fix for #111
+        obj.setProperty('Textures', True)
+    elif colorMode == 'URDF Colors':
+        obj.useUrdfColors = True
+
     if view is not None:
         obj.addToView(view)
 


### PR DESCRIPTION
This is a working fix for #111, tested with Atlas v3, v4, v5, Valkyrie v1, v2, and the Kuka LWR. It sets the rendering mode to URDF Colors by default and overwrites it to "Texture" if given in the directorConfig

Goes along with https://github.com/openhumanoids/main-distro/pull/2196