### PR TITLE
URDF/Texture Solid Color Toggling Fix

### DIFF
--- a/src/python/ddapp/roboturdf.py
+++ b/src/python/ddapp/roboturdf.py
@@ -206,6 +206,7 @@ def loadRobotModel(name, view=None, parent='planning', urdfFile=None, color=None
     obj.setProperty('Color', color or getRobotGrayColor())
     if colorMode == 'Texture': # fix for #111
         obj.setProperty('Textures', True)
+        obj.useUrdfColors = False
     elif colorMode == 'Solid Color':
         obj.useUrdfColors = False
         obj._updateModelColor()


### PR DESCRIPTION
This fixes a bug @mauricefallon spotted that I introduced in #113 - toggling solid colors was broken when operating with textures. This PR allows for toggling between solid colors and textures, e.g. for the playback model