### PR TITLE
allow runtime config designer

### DIFF
--- a/src/python/ddapp/startup.py
+++ b/src/python/ddapp/startup.py
@@ -171,7 +171,7 @@ if 'fixedBaseArm' in drcargs.getDirectorConfig()['userConfig']:
 if 'disableComponents' in drcargs.getDirectorConfig():
     for component in drcargs.getDirectorConfig()['disableComponents']:
         print "Disabling", component
-        exec(component + " = False")
+        locals()[component] = False
 
 
 if useSpreadsheet:

--- a/src/python/ddapp/startup.py
+++ b/src/python/ddapp/startup.py
@@ -166,17 +166,12 @@ useMappingPanel = True
 poseCollection = PythonQt.dd.ddSignalMap()
 costCollection = PythonQt.dd.ddSignalMap()
 
-
 if 'fixedBaseArm' in drcargs.getDirectorConfig()['userConfig']:
     ikPlanner.fixedBaseArm = True
-if 'useFootstepsDisable' in drcargs.getDirectorConfig()['userConfig']:
-    useFootsteps = False
-if 'usePlanningDisable' in drcargs.getDirectorConfig()['userConfig']:
-    usePlanning = False
-if 'useFootContactVisDisable' in drcargs.getDirectorConfig()['userConfig']:
-    useFootContactVis = False
-if 'useCOPMonitorDisable' in drcargs.getDirectorConfig()['userConfig']:
-    useCOPMonitor = False
+if 'disableComponents' in drcargs.getDirectorConfig():
+    for component in drcargs.getDirectorConfig()['disableComponents']:
+        print "Disabling", component
+        exec(component + " = False")
 
 
 if useSpreadsheet:

--- a/src/python/ddapp/startup.py
+++ b/src/python/ddapp/startup.py
@@ -166,6 +166,19 @@ useMappingPanel = True
 poseCollection = PythonQt.dd.ddSignalMap()
 costCollection = PythonQt.dd.ddSignalMap()
 
+
+if 'fixedBaseArm' in drcargs.getDirectorConfig()['userConfig']:
+    ikPlanner.fixedBaseArm = True
+if 'useFootstepsDisable' in drcargs.getDirectorConfig()['userConfig']:
+    useFootsteps = False
+if 'usePlanningDisable' in drcargs.getDirectorConfig()['userConfig']:
+    usePlanning = False
+if 'useFootContactVisDisable' in drcargs.getDirectorConfig()['userConfig']:
+    useFootContactVis = False
+if 'useCOPMonitorDisable' in drcargs.getDirectorConfig()['userConfig']:
+    useCOPMonitor = False
+
+
 if useSpreadsheet:
     spreadsheet.init(poseCollection, costCollection)
 
@@ -283,7 +296,6 @@ if useNavigationPanel:
     navigationPanel = navigationpanel.init(robotStateJointController, footstepsDriver)
     picker = PointPicker(view, callback=navigationPanel.pointPickerStoredFootsteps, numberOfPoints=2)
     #picker.start()
-
 
 if usePlanning:
 
@@ -412,9 +424,6 @@ if usePlanning:
         affordancePanel.onGetRaycastTerrain()
 
     ikPlanner.addPostureGoalListener(robotStateJointController)
-
-    if 'fixedBaseArm' in drcargs.getDirectorConfig()['userConfig']:
-        ikPlanner.fixedBaseArm = True
 
     playbackPanel = playbackpanel.init(planPlayback, playbackRobotModel, playbackJointController,
                                       robotStateModel, robotStateJointController, manipPlanner)


### PR DESCRIPTION
this evaluates a list of strings at the top of startup.py and disables the components e.g.:
this disables drake planning but will draw a robot and render sensor data:
  "disableComponents" : ["useFootsteps","usePlanning","useFootContactVis","useCOPMonitor"]