### PR TITLE
Slider board midi

### DIFF
--- a/src/python/director/midi.py
+++ b/src/python/director/midi.py
@@ -3,6 +3,8 @@
 import pypm
 import array
 import time
+import inspect
+import threading
 
 class TriggerFinger(object):
     pads = range(1,17)
@@ -44,6 +46,14 @@ def findInputDevice(deviceName):
         if inp and (deviceName in name):
                 return deviceId
 
+def findOutDevice(deviceName):
+
+    init()
+    for deviceId in xrange(pypm.CountDevices()):
+        interf, name, inp, outp, opened = pypm.GetDeviceInfo(deviceId)
+        if outp and (deviceName in name):
+                return deviceId
+
 
 def findTriggerFinger():
     return findInputDevice('USB Trigger Finger MIDI')
@@ -53,6 +63,100 @@ def findKorgNanoKontrol2():
     if deviceId is None:
         deviceId = findInputDevice('nanoKONTROL2 MIDI 1')
     return deviceId
+
+class IOControl:
+    def __init__(self, id, getter, data):
+        assert id>0 and id<93
+        arg=inspect.getargspec(getter).args
+        assert (len(arg)==2 and arg[0]!='self') or (len(arg)==3 and arg[0]=='self')
+        self.id=id
+        self.getter=getter
+        self.send=None
+        self.data=data
+        self.value=0
+
+    def setter(self,val):
+        if self.send is not None:
+            val=int(min(max(0,val),127))
+            self.value=val
+            self.send([self.id, val])
+
+    def setSender(self, sender):
+        self.send=sender
+
+class BehringerBCF200(object):
+    def __init__(self, deviceIdIn=None, deviceIdOut=None):
+        init()
+
+        if deviceIdIn is None:
+            deviceIdIn = findInputDevice('BCF2000 MIDI 1')
+        if deviceIdOut is None:
+            deviceIdOut = findOutDevice('BCF2000 MIDI 1')
+
+        assert deviceIdIn is not None
+        assert deviceIdOut is not None
+
+        self.streamIn = pypm.Input(deviceIdIn)
+        self.streamOut = pypm.Output(deviceIdOut,0)
+        self.vars = [None]*96
+        self.polling=True
+        self.thread = threading.Thread(target=self.pollingThread)
+        self.thread.setDaemon(True)
+        self.thread.start();
+
+    def pollingThread(self):
+        while(self.polling):
+            msg=self.getNextMessage()
+            if msg is not None and msg[1]>0 and msg[1]<93 and self.vars[msg[1]] is not None:
+                self.vars[msg[1]].getter(msg[2],self.vars[msg[1]].data)
+                self.vars[msg[1]].value=msg[2]
+            time.sleep(0)
+
+
+    def addVarieble(self, var):
+        self.vars[var.id]=var
+        self.vars[var.id].send=self.sendMessage
+
+    def clear(self):
+        for var in self.vars:
+            if var is not None:
+                var.send=None
+        self.vars = [None]*96
+
+    def _convertMessage(self, streamMessage):
+        '''
+        Given a stream message [[b1, b2, b3, b4], timestamp]
+        Return [timestamp, b1, b2, b3, b4]
+        '''
+        midiData, timestamp = streamMessage
+        b1, b2, b3, b4 = midiData
+        return [timestamp, b2, b3]
+
+    def getNextMessage(self):
+        '''
+        Returns the next message in the buffer.
+        Does not block.  Returns None if buffer is empty.
+        '''
+        if self.streamIn.Poll():
+            message = self.streamIn.Read(1)[0]
+            return self._convertMessage(message)
+
+    def getMessages(self):
+        '''
+        Returns a list of all messages currently in the buffer, up to 1024 messages.
+        Does not block.  Returns empty list if buffer is empty.
+        '''
+        if self.streamIn.Poll():
+            messages = self.streamIn.Read(1024)
+            return [self._convertMessage(message) for message in messages]
+        return []
+
+    def sendMessage(self, data):
+        '''
+        Sends data to the slider board.
+        '''
+        assert len(data)==2
+        self.streamOut.Write([[[176,data[0],data[1]],0]])
 
 class MidiReader(object):
 

--- a/src/python/director/teleoppanel.py
+++ b/src/python/director/teleoppanel.py
@@ -15,6 +15,7 @@ from director.roboturdf import HandFactory
 from director import lcmUtils
 import drc as lcmdrc
 
+import director.midi as midi
 import functools
 import math
 import numpy as np
@@ -1063,8 +1064,52 @@ class JointTeleopPanel(object):
         self.endPose = None
         self.userJoints = {}
 
+        self.active=False
+
+        self.behringer=None
+
         self.updateWidgetState()
 
+        # Attach Behringer slider board if connected
+        device = midi.findInputDevice('BCF2000 MIDI 1')
+        if device is not None:
+            self.behringer = midi.BehringerBCF200()
+            self.behringerCallback = TimerCallback()
+            self.behringerCallback.callback = self.onBehringerCallback
+            self.behringerValues={}
+            self.setupSliderBoard()
+
+
+    def setupSliderBoard(self):
+        self.sliderBoardGroup={}
+        self.controls={}
+        self.tabControls=[]
+        for i in range(0,9):
+            self.tabControls.append(midi.IOControl(73+i,self.sliderBoardTabGetter,i))
+
+        for group in self.jointGroups:
+            groupName = group['name']
+            joints = group['joints']
+            controls={}
+            i=0
+            for jointName in joints:
+                controls[jointName]=midi.IOControl(81+i,self.sliderBoardGetter,jointName)
+                self.controls[jointName]=controls[jointName]
+                self.behringerValues[jointName]=-1
+                i=i+1
+            self.sliderBoardGroup[groupName]=controls
+
+    def sliderBoardTabGetter(self,val,id):
+        if id>=0 and id<self.ui.tabWidget.count:
+            self.ui.tabWidget.currentIndex=id
+        else:
+            self.behringer.sendMessage([73+id,0])
+
+
+
+    def sliderBoardGetter(self,val,sliderName):
+       slider=self.slidersMap[sliderName]
+       self.behringerValues[sliderName]=int(float(val)/127.0*float(self.sliderMax))
 
     def buildTabWidget(self, jointGroups):
 
@@ -1099,6 +1144,8 @@ class JointTeleopPanel(object):
 
         self.signalMapper = QtCore.QSignalMapper()
 
+        self.ui.tabWidget.connect('currentChanged(int)', self.tabChenged)
+
         self.sliderMax = 1000.0
         for jointName, slider in self.slidersMap.iteritems():
             slider.connect('valueChanged(int)', self.signalMapper, 'map()')
@@ -1106,6 +1153,27 @@ class JointTeleopPanel(object):
             slider.setMaximum(self.sliderMax)
 
         self.signalMapper.connect('mapped(const QString&)', self.sliderChanged)
+
+    def tabChenged(self, id):
+        tab=self.ui.tabWidget.tabText(id)
+        if self.behringer is not None and self.active:
+            for i in range(0,8):
+                if i==id:
+                    self.behringer.sendMessage([73+i,127])
+                else:
+                    self.behringer.sendMessage([73+i,0])
+            self.behringer.clear()
+            for tab_ in self.tabControls:
+                self.behringer.addVarieble(tab_)
+            i=0
+            for jointName,ctrl in self.sliderBoardGroup[tab].iteritems():
+                self.behringer.addVarieble(ctrl)
+                slider = self.slidersMap[jointName]
+                ctrl.setter((slider.value / float(self.sliderMax))*127)
+                self.behringerValues[jointName] = slider.value
+                i=i+1
+            for j in range(i,8):
+                self.behringer.sendMessage([81+j,0])
 
 
     def planClicked(self):
@@ -1135,13 +1203,21 @@ class JointTeleopPanel(object):
 
 
     def activate(self):
+        self.active=True
+        if self.behringer is not None:
+            self.behringerCallback.start()
         self.timerCallback.stop()
         self.panel.jointTeleopActivated()
         self.resetPose()
+        self.tabChenged(self.ui.tabWidget.currentIndex)
         self.updateWidgetState()
 
 
     def deactivate(self):
+        if self.behringer is not None:
+            self.behringer.clear()
+            self.behringerCallback.stop()
+        self.active=False
         self.ui.jointTeleopButton.blockSignals(True)
         self.ui.jointTeleopButton.checked = False
         self.ui.jointTeleopButton.blockSignals(False)
@@ -1154,8 +1230,10 @@ class JointTeleopPanel(object):
 
         enabled = self.ui.jointTeleopButton.checked
 
-        for slider in self.slidersMap.values():
+        for jointName, slider in self.slidersMap.iteritems():
             slider.setEnabled(enabled)
+            if self.behringer is not None:
+                self.behringerValues[jointName]=slider.value
 
         self.ui.resetJointsButton.setEnabled(enabled)
 
@@ -1169,6 +1247,15 @@ class JointTeleopPanel(object):
 
     def resetPose(self):
         self.userJoints = {}
+        if self.behringer is not None:
+            self.startPose = np.array(self.panel.robotStateJointController.q)
+            for jointName, slider in self.slidersMap.iteritems():
+                jointIndex = self.toJointIndex(jointName)
+                self.behringerValues[jointName]=self.toSliderValue(jointIndex,self.startPose[jointIndex])
+                slider.blockSignals(True)
+                slider.value=self.behringerValues[jointName]
+                slider.blockSignals(False)
+                self.controls[jointName].setter((slider.value / float(self.sliderMax))*127)
         self.computeEndPose()
         self.updateSliders()
 
@@ -1176,6 +1263,29 @@ class JointTeleopPanel(object):
         if not self.ui.tabWidget.visible:
             return
         self.resetPose()
+
+    def onBehringerCallback(self):
+        if not self.ui.tabWidget.visible:
+            return
+        updatePose=False
+        for jointName, slider in self.slidersMap.iteritems():
+            if self.behringerValues[jointName] != slider.value:
+                slider.blockSignals(True)
+                slider.value=self.behringerValues[jointName]
+                slider.blockSignals(False)
+                jointIndex = self.toJointIndex(jointName)
+                jointValue = self.toJointValue(jointIndex, slider.value / float(self.sliderMax))
+                self.userJoints[jointIndex] = jointValue
+                if jointName.startswith('base_'):
+                    self.computeBaseJointOffsets()
+                    self.userJoints[jointIndex] += self.baseJointOffsets.get(jointName, 0.0)
+                self.updateLabel(jointName, jointValue)
+                updatePose=True
+
+
+        if updatePose:
+            self.computeEndPose()
+            self.panel.showPose(self.endPose)
 
     def toJointIndex(self, jointName):
         return robotstate.getDrakePoseJointNames().index(jointName)
@@ -1258,12 +1368,13 @@ class JointTeleopPanel(object):
     def getJointValue(self, jointIndex):
         return self.endPose[jointIndex]
 
-
-    def sliderChanged(self, jointName):
-
+    def updateSliderValues(self, jointName, sendToSliderBoard):
         slider = self.slidersMap[jointName]
         jointIndex = self.toJointIndex(jointName)
         jointValue = self.toJointValue(jointIndex, slider.value / float(self.sliderMax))
+        if self.behringer is not None and sendToSliderBoard:
+            self.controls[jointName].setter((slider.value / float(self.sliderMax))*127)
+            self.behringerValues[jointName]=slider.value
         self.userJoints[jointIndex] = jointValue
 
         if jointName.startswith('base_'):
@@ -1273,6 +1384,10 @@ class JointTeleopPanel(object):
         self.computeEndPose()
         self.panel.showPose(self.endPose)
         self.updateLabel(jointName, jointValue)
+
+    def sliderChanged(self, jointName):
+        self.updateSliderValues(jointName, True)
+
 
     def updateLabel(self, jointName, jointValue):
 
@@ -1302,8 +1417,16 @@ class JointTeleopPanel(object):
 
             slider.blockSignals(True)
             slider.setValue(self.toSliderValue(jointIndex, jointValue)*self.sliderMax)
+            if self.behringer is not None:
+                self.behringerValues[jointName]=slider.value
             slider.blockSignals(False)
             self.updateLabel(jointName, jointValue)
+
+        if self.behringer is not None and self.active:
+            tab=self.ui.tabWidget.tabText(self.ui.tabWidget.currentIndex)
+            for jointName,ctrl in self.controls.iteritems():
+                slider = self.slidersMap[jointName]
+                ctrl.setter((slider.value / float(self.sliderMax))*127)
 
 
 class TeleopPanel(object):


### PR DESCRIPTION
 - Added support for Behringer BCF2000 midi slider board.
 - Hooked up the slider board to joint teleop panel.

When the board is not connect, joint teleop behaves as usual.

https://youtu.be/Nwju1w1DaPM