### PR TITLE
Color Mode, per #111

### DIFF
--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -76,6 +76,7 @@ class ddMeshVisual
   vtkSmartPointer<vtkTransform> Transform;
   vtkSmartPointer<vtkTransform> VisualToLink;
   vtkSmartPointer<vtkTexture> Texture;
+  QColor Color;
   std::string Name;
 
 private:
@@ -667,6 +668,7 @@ public:
           meshVisual->Name = body->linkname;
           meshMap[body].push_back(meshVisual);
 
+          meshVisual->Color = QColor(visual.getMaterial()[0]*255, visual.getMaterial()[1]*255, visual.getMaterial()[2]*255);
           meshVisual->Actor->GetProperty()->SetColor(visual.getMaterial()[0],
                                                      visual.getMaterial()[1],
                                                      visual.getMaterial()[2]);

--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -1304,6 +1304,20 @@ void ddDrakeModel::setColor(const QColor& color)
 }
 
 //-----------------------------------------------------------------------------
+void ddDrakeModel::setUrdfColors()
+{
+  //std::cout << "Set Urdf Colors" << std::endl;
+  std::vector<ddMeshVisual::Ptr> visuals = this->Internal->Model->meshVisuals();
+  for (size_t i = 0; i < visuals.size(); ++i)
+  {
+    visuals[i]->Actor->GetProperty()->SetColor(visuals[i]->Color.redF(),
+                                               visuals[i]->Color.greenF(),
+                                               visuals[i]->Color.blueF());
+  }
+  emit this->displayChanged();
+}
+
+//-----------------------------------------------------------------------------
 bool ddDrakeModel::texturesEnabled() const
 {
   return this->Internal->TexturesEnabled;

--- a/src/app/ddDrakeModel.h
+++ b/src/app/ddDrakeModel.h
@@ -53,6 +53,8 @@ public:
   void setAlpha(double alpha);
   double alpha() const;
 
+  void setUrdfColors();
+
   void setTexturesEnabled(bool enabled);
   bool texturesEnabled() const;
 

--- a/src/app/wrapped_methods_drake.txt
+++ b/src/app/wrapped_methods_drake.txt
@@ -20,6 +20,7 @@ int ddDrakeModel::findLinkID(const QString&) const;
 void ddDrakeModel::setAlpha(double);
 void ddDrakeModel::setVisible(bool);
 void ddDrakeModel::setTexturesEnabled(bool);
+void ddDrakeModel::setUrdfColors();
 QColor ddDrakeModel::color() const;
 void ddDrakeModel::setColor(const QColor&);
 void ddDrakeModel::setLinkColor(const QString&, const QColor&);

--- a/src/python/director/robotsystem.py
+++ b/src/python/director/robotsystem.py
@@ -72,7 +72,7 @@ class RobotSystem(object):
         # Determine colorMode, fix for #111
         colorMode = 'URDF Colors' # URDF colors by default
         if 'colorMode' in directorConfig:
-            assert directorConfig['colorMode'] in ['URDF Colors', 'Solid Color', 'Texture']
+            assert directorConfig['colorMode'] in ['URDF Colors', 'Solid Color', 'Textures']
             colorMode = directorConfig['colorMode']
 
 

--- a/src/python/director/roboturdf.py
+++ b/src/python/director/roboturdf.py
@@ -204,7 +204,7 @@ def loadRobotModel(name, view=None, parent='planning', urdfFile=None, color=None
     obj.setProperty('Visible', visible)
     obj.setProperty('Name', name)
     obj.setProperty('Color', color or getRobotGrayColor())
-    if colorMode == 'Texture': # fix for #111
+    if colorMode == 'Textures': # fix for #111
         obj.setProperty('Textures', True)
         obj.useUrdfColors = False
     elif colorMode == 'Solid Color':

--- a/src/python/director/roboturdf.py
+++ b/src/python/director/roboturdf.py
@@ -55,7 +55,6 @@ class RobotModelItem(om.ObjectModelItem):
         self.views = []
         self.model = None
         self.callbacks.addSignal(self.MODEL_CHANGED_SIGNAL)
-        self.useUrdfColors = True
 
         self.addProperty('Filename', model.filename())
         self.addProperty('Visible', model.visible())
@@ -77,15 +76,10 @@ class RobotModelItem(om.ObjectModelItem):
         elif propertyName == 'Visible':
             self.model.setVisible(self.getProperty(propertyName))
         elif propertyName == 'Color Mode':
-            if self.getProperty(propertyName) == 0: # Solid Color
-                self.useUrdfColors = False
-                self.model.setTexturesEnabled(False)
-            elif self.getProperty(propertyName) == 1: # Textures
-                self.useUrdfColors = False
+            if self.getProperty(propertyName) == 1: # Textures
                 self.model.setTexturesEnabled(True)
-            elif self.getProperty(propertyName) == 2: # URDF Colors
+            else:
                 self.model.setTexturesEnabled(False)
-                self.useUrdfColors = True
             self._updateModelColor()
         elif propertyName == 'Color':
             self._updateModelColor()
@@ -155,12 +149,13 @@ class RobotModelItem(om.ObjectModelItem):
         self.onModelChanged()
 
     def _updateModelColor(self):
-        if self.getProperty('Color Mode') == 1: # Textures
-            self._setupTextureColors()
-        elif not self.useUrdfColors:
+        if self.getProperty('Color Mode') == 0: # Solid Color
             color = QtGui.QColor(*[c*255 for c in self.getProperty('Color')])
             self.model.setColor(color)
-        # TODO (fix for #111): add getLinkColor iterating over all joints and setting color after fixing ddDrakeModel.cpp
+        elif self.getProperty('Color Mode') == 1: # Textures
+            self._setupTextureColors()
+        elif self.getProperty('Color Mode') == 2: # URDF Colors
+            self.model.setUrdfColors()
 
     def _setupTextureColors(self):
 

--- a/src/python/director/roboturdf.py
+++ b/src/python/director/roboturdf.py
@@ -62,8 +62,7 @@ class RobotModelItem(om.ObjectModelItem):
         self.addProperty('Alpha', model.alpha(),
                          attributes=om.PropertyAttributes(decimals=2, minimum=0, maximum=1.0, singleStep=0.1, hidden=False))
         self.addProperty('Color Mode', 0,
-                         attributes=om.PropertyAttributes(
-                            enumNames=['Solid Color', 'Textures', 'URDF Colors']))
+                         attributes=om.PropertyAttributes(enumNames=['Solid Color', 'Textures', 'URDF Colors']))
         self.addProperty('Color', model.color())
 
 


### PR DESCRIPTION
Pat, apologies for closing the issue without adding the color mode enum first (I wasnt aware of that fact and should have asked before closing).

Were you looking for something along the lines of this? This adds a enum for Color Mode and populates it with "Solid Color" per default, and then changes it according to a director config parameter to Textures or URDF Colors. I also changed "Texture" to "Textures" to have a common naming convention, cf. https://github.com/openhumanoids/main-distro/pull/2230.

This removes the Textures boolean property and replaces it with a Color Mode enum. Tested on v5, val2, lwr.

![screenshot from 2015-11-23 17 25 28](https://cloud.githubusercontent.com/assets/1664508/11344195/bd0b19de-9207-11e5-9ff2-623f1b5e1c1d.png)

Addresses, and potentially closes #111 
