### PR TITLE
Added command line argument to load Valkyrie with simplified models

### DIFF
--- a/src/python/director/drcargs.py
+++ b/src/python/director/drcargs.py
@@ -60,6 +60,10 @@ class DRCArgParser(object):
         return os.path.join(director.getDRCBaseDir(),
                             'software/models/val_description/director_config.json')
 
+    def getDefaultValkyrieV2SimpleDirectorConfigFile(self):
+        return os.path.join(director.getDRCBaseDir(),
+                            'software/models/val_description/director_config_simple.json')
+
     def getDefaultKukaLWRConfigFile(self):
         return os.path.join(director.getDRCBaseDir(),
                             'software/models/lwr_defs/director_config.json')
@@ -97,6 +101,13 @@ class DRCArgParser(object):
                             action='store_const',
                             const=self.getDefaultValkyrieV2DirectorConfigFile(),
                             help='Use Valkyrie')
+
+        directorConfig.add_argument('-val2s', '--valkyrie_v2_simple', dest='directorConfigFile',
+                            action='store_const',
+                            const=self.getDefaultValkyrieV2SimpleDirectorConfigFile(),
+                            help='Use Valkyrie')
+
+
 
         directorConfig.add_argument('-lwr', '--lwr', dest='directorConfigFile',
                             action='store_const',


### PR DESCRIPTION
Changing the command line argument from ```-val2``` to ```-val2s``` will load a set of simplified URDFs that use only basic shapes (coxes, spheres, and cylinders).

This uses openhumanoids/main-distro#2243