### PR TITLE
Fix vtkDRCFilters for octomaps to add compatibility with newer octomap versions

### DIFF
--- a/src/vtk/DRCFilters/vtkOctomap.cxx
+++ b/src/vtk/DRCFilters/vtkOctomap.cxx
@@ -230,7 +230,19 @@ void MyOcTreeDrawer::setOcTree(const octomap::OcTree& octree, double minDrawZ, d
 
   if (m_drawOccupied) {
     int numremoved = 0;
-    octree.getOccupied(occupiedThresVoxels, occupiedVoxels, m_max_tree_depth);
+    for (octomap::OcTree::tree_iterator it = octree.begin_tree(m_max_tree_depth), end=octree.end_tree(); it!= end; ++it) {
+      if (it.isLeaf()) { // leaf nodes only, to be removed if wanting to include inner nodes
+        octomap::OcTreeVolume voxel = OcTreeVolume(it.getCoordinate(), it.getSize());
+
+        if (octree.isNodeOccupied(*it)) {
+          if (octree.isNodeAtThreshold(*it)) {
+            occupiedThresVoxels.push_back(voxel);
+          } else {
+            occupiedVoxels.push_back(voxel);
+          }
+        }
+      }
+    }
 
     int size1 = occupiedVoxels.size();
     int size2 = occupiedThresVoxels.size();
@@ -258,7 +270,19 @@ void MyOcTreeDrawer::setOcTree(const octomap::OcTree& octree, double minDrawZ, d
   }
 
   if (m_drawFree) {
-    octree.getFreespace(freeThresVoxels, freeVoxels, m_max_tree_depth);
+    for (octomap::OcTree::tree_iterator it = octree.begin_tree(m_max_tree_depth), end=octree.end_tree(); it!= end; ++it) {
+      if (it.isLeaf()) { // leaf nodes only, to be removed if wanting to include inner nodes
+        octomap::OcTreeVolume voxel = OcTreeVolume(it.getCoordinate(), it.getSize());
+
+        if (!octree.isNodeOccupied(*it)) {
+          if (octree.isNodeAtThreshold(*it)) {
+            freeThresVoxels.push_back(voxel);
+          } else {
+            freeVoxels.push_back(voxel);
+          }
+        }
+      }
+    }
     int numremoved = 0;
     int size1 = freeVoxels.size();
     int size2 = freeThresVoxels.size();


### PR DESCRIPTION
Relates to https://github.com/openhumanoids/main-distro/issues/2067

Makes director compatible with newer octomap versions, tested with v1.7.0 (current release). This is the same patch as for the renderer_octomap.cpp in common_utils, which is also used in pronto.

cc: @patmarion & @mauricefallon 