### PR TITLE
import iris earlier to avoid import error

### DIFF
--- a/src/python/director/irisUtils.py
+++ b/src/python/director/irisUtils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import drc as lcmdrc
-from director.lcmframe import frameFromPositionMessage, positionMessageFromFrame
 from irispy.utils import lcon_to_vert
+from director.lcmframe import frameFromPositionMessage, positionMessageFromFrame
 from scipy.spatial import ConvexHull
 
 

--- a/src/python/director/irisdriver.py
+++ b/src/python/director/irisdriver.py
@@ -2,10 +2,10 @@ from __future__ import division
 
 import numpy as np
 import drc as lcmdrc
+from director import irisUtils
 from director import applogic as app
 from director import objectmodel as om
 from director import transformUtils
-from director import irisUtils
 from director import lcmUtils
 from director import robotstate
 from director.terrainitem import TerrainRegionItem


### PR DESCRIPTION
On some systems we are getting the import error:

ImportError: dlopen: cannot load any more object with static TLS

which seems to be coming from the swig layer of iris.  The issue is
avoided by importing iris earlier.  It seems to be interacting in a
strange way with other modules loaded by director.