### PR TITLE
Flip imageOverlay camera based on head frame

### DIFF
--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -417,6 +417,7 @@ class CameraImageView(object):
 
         imageManager.addImage(imageName)
 
+        self.cameraRoll = None
         self.imageManager = imageManager
         self.viewName = viewName or imageName
         self.imageName = imageName
@@ -509,12 +510,20 @@ class CameraImageView(object):
         self.eventFilter.connect('handleEvent(QObject*, QEvent*)', self.filterEvent)
         self.eventFilterEnabled = True
 
+    def setCameraRoll(self, roll):
+        self.cameraRoll = roll
+        self.resetCamera()
+
     def resetCamera(self):
         camera = self.view.camera()
         camera.ParallelProjectionOn()
         camera.SetFocalPoint(0,0,0)
         camera.SetPosition(0,0,-1)
         camera.SetViewUp(0,-1, 0)
+
+        if self.cameraRoll is not None:
+            camera.SetRoll(self.cameraRoll)
+
         self.view.resetCamera()
         self.fitImageToView()
         self.view.render()

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -566,7 +566,6 @@ class CameraFrustumVisualizer(object):
         self.cameraName = cameraName
         self.imageManager = imageManager
         self.rayLength = 2.0
-        self.headLink = drcargs.getDirectorConfig()['headLink']
         robotModel.connectModelChanged(self.update)
         self.update(robotModel)
 
@@ -579,10 +578,9 @@ class CameraFrustumVisualizer(object):
         Returns cameraToLocal.  cameraToHead is pulled from bot frames while
         headToLocal is pulled from the robot model forward kinematics.
         '''
-        headToLocal = self.robotModel.getLinkFrame( self.headLink )
+        headToLocal = self.robotModel.getLinkFrame( self.robotModel.getHeadLink() )
         cameraToHead = vtk.vtkTransform()
-        # TODO: 'head' should match self.headLink
-        self.imageManager.queue.getTransform(self.cameraName, 'head', 0, cameraToHead)
+        self.imageManager.queue.getTransform(self.cameraName, self.robotModel.getHeadLink(), 0, cameraToHead)
         return transformUtils.concatenateTransforms([cameraToHead, headToLocal])
 
     def getCameraFrustumRays(self):

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -764,6 +764,13 @@ def getLinkFrame(linkName, model=None):
     return model.getLinkFrame(linkName)
 
 
+def getBotFrame(frameName):
+    t = vtk.vtkTransform()
+    t.PostMultiply()
+    cameraview.imageManager.queue.getTransform(frameName, 'local', t)
+    return t
+
+
 def showLinkFrame(linkName, model=None):
     frame = getLinkFrame(linkName, model)
     if not frame:

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -716,6 +716,14 @@ class ImageOverlayManager(object):
         imageView.view.setParent(view)
         imageView.view.resize(self.size, self.size)
         imageView.view.move(*self.position)
+
+        if self.viewName is 'CAMERA_LEFT':
+            # Rotate Multisense image/CAMERA_LEFT if the camera frame is rotated (e.g. for Valkyrie)
+            tf = robotStateModel.getLinkFrame(robotStateModel.getHeadLink())
+            roll = transformUtils.rollPitchYawFromTransform(tf)[0]
+            if np.isclose(np.abs(roll), np.pi, atol=1e-1):
+                imageView.setCameraRoll(0)
+
         imageView.view.show()
 
         if self.usePicker:


### PR DESCRIPTION
Reads the roll of the head frame and rotates the imageOverlay accordingly (to automatically account for the Valkyrie/Atlas Multisense rotation for instance). Next up is the same for the Camera View field.