### PR TITLE
Flip images in ImageManager if camera frame is rotated

### DIFF
--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -211,6 +211,7 @@ class CameraView(object):
 
         self.imageManager = imageManager
         self.updateUtimes = {}
+        self.robotModel = None
         self.sphereObjects = {}
         self.sphereImages = [
                 'CAMERA_LEFT',
@@ -273,6 +274,15 @@ class CameraView(object):
         self.eventFilter.addFilteredEventType(QtCore.QEvent.MouseButtonDblClick)
         self.eventFilter.addFilteredEventType(QtCore.QEvent.KeyPress)
         self.eventFilter.connect('handleEvent(QObject*, QEvent*)', self.filterEvent)
+
+    def initImageRotations(self, robotModel):
+        self.robotModel = robotModel
+        # Rotate Multisense image/CAMERA_LEFT if the camera frame is rotated (e.g. for Valkyrie)
+        if robotModel.getHeadLink():
+            tf = robotModel.getLinkFrame(robotModel.getHeadLink())
+            roll = transformUtils.rollPitchYawFromTransform(tf)[0]
+            if np.isclose(np.abs(roll), np.pi, atol=1e-1):
+                self.imageManager.setImageRotation180('CAMERA_LEFT')
 
     def initView(self, view):
 

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -113,6 +113,7 @@ class ImageManager(object):
         self.images = {}
         self.imageUtimes = {}
         self.textures = {}
+        self.imageRotations180 = {}
 
         self.queue = PythonQt.dd.ddBotImageQueue(lcmUtils.getGlobalLCMThread())
         self.queue.init(lcmUtils.getGlobalLCMThread(), drcargs.args().config_file)
@@ -132,6 +133,7 @@ class ImageManager(object):
         self.imageUtimes[name] = 0
         self.images[name] = image
         self.textures[name] = tex
+        self.imageRotations180[name] = None
 
     def writeImage(self, imageName, outFile):
         writer = vtk.vtkPNGWriter()
@@ -149,6 +151,10 @@ class ImageManager(object):
     def updateImages(self):
         for imageName in self.images.keys():
             self.updateImage(imageName)
+
+    def setImageRotation180(self, imageName):
+        assert imageName in self.images
+        self.imageRotations180[imageName] = True
 
     def hasImage(self, imageName):
         return imageName in self.images

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -146,6 +146,10 @@ class ImageManager(object):
         if imageUtime != self.imageUtimes[imageName]:
             image = self.images[imageName]
             self.imageUtimes[imageName] = self.queue.getImage(imageName, image)
+
+            if self.imageRotations180[imageName] is not None:
+                self.images[imageName].ShallowCopy(filterUtils.rotateImage180(image))
+
         return imageUtime
 
     def updateImages(self):

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -133,7 +133,7 @@ class ImageManager(object):
         self.imageUtimes[name] = 0
         self.images[name] = image
         self.textures[name] = tex
-        self.imageRotations180[name] = None
+        self.imageRotations180[name] = False
 
     def writeImage(self, imageName, outFile):
         writer = vtk.vtkPNGWriter()
@@ -147,7 +147,7 @@ class ImageManager(object):
             image = self.images[imageName]
             self.imageUtimes[imageName] = self.queue.getImage(imageName, image)
 
-            if self.imageRotations180[imageName] is not None:
+            if self.imageRotations180[imageName]:
                 self.images[imageName].ShallowCopy(filterUtils.rotateImage180(image))
 
         return imageUtime

--- a/src/python/director/filterUtils.py
+++ b/src/python/director/filterUtils.py
@@ -128,4 +128,4 @@ def rotateImage180(image):
     r2.SetInput(r1.GetOutput())
     r2.SetFilteredAxis(1)
     r2.Update()
-    return r2.GetOutput()
+    return shallowCopy(r2.GetOutput())

--- a/src/python/director/filterUtils.py
+++ b/src/python/director/filterUtils.py
@@ -114,3 +114,18 @@ def removeNonFinitePoints(polyData, arrayName='Points'):
     polyData = shallowCopy(polyData)
     labelNonFinitePoints(polyData, arrayName)
     return thresholdPoints(polyData, 'is_nonfinite', [0, 0])
+
+
+def rotateImage180(image):
+    '''
+    rotates an image by 180 degrees
+    '''
+    r1 = vtk.vtkImageFlip()
+    r1.SetInput(image)
+    r1.SetFilteredAxis(0)
+    r1.Update()
+    r2 = vtk.vtkImageFlip()
+    r2.SetInput(r1.GetOutput())
+    r2.SetFilteredAxis(1)
+    r2.Update()
+    return r2.GetOutput()

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -1077,6 +1077,14 @@ if 'exo' in drcargs.args():
     if (drcargs.args().exo):
         ikPlanner.pushToMatlab = False
 
+# Rotate Multisense image/CAMERA_LEFT if the camera frame is rotated (e.g. for Valkyrie)
+if robotStateModel.getHeadLink():
+    tf = robotStateModel.getLinkFrame(robotStateModel.getHeadLink())
+    roll = transformUtils.rollPitchYawFromTransform(tf)[0]
+    if np.isclose(np.abs(roll), np.pi, atol=1e-1):
+        cameraview.imageManager.setImageRotation180('CAMERA_LEFT')
+
+
 def roomMap():
     mappingPanel.onStartMappingButton()
     t = mappingdemo.MappingDemo(robotStateModel, playbackRobotModel,

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -203,6 +203,7 @@ if usePerception:
     cameraview.init()
     colorize.init()
 
+    cameraview.cameraView.initImageRotations(robotStateModel)
     cameraview.cameraView.rayCallback = segmentation.extractPointsAlongClickRay
     multisensepanel.init(perception.multisenseDriver, neckDriver)
     sensordatarequestpanel.init()
@@ -1068,13 +1069,6 @@ if 'useKuka' in drcargs.getDirectorConfig()['userConfig']:
 if 'exo' in drcargs.args():
     if (drcargs.args().exo):
         ikPlanner.pushToMatlab = False
-
-# Rotate Multisense image/CAMERA_LEFT if the camera frame is rotated (e.g. for Valkyrie)
-if robotStateModel.getHeadLink():
-    tf = robotStateModel.getLinkFrame(robotStateModel.getHeadLink())
-    roll = transformUtils.rollPitchYawFromTransform(tf)[0]
-    if np.isclose(np.abs(roll), np.pi, atol=1e-1):
-        cameraview.imageManager.setImageRotation180('CAMERA_LEFT')
 
 
 def roomMap():

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -716,14 +716,6 @@ class ImageOverlayManager(object):
         imageView.view.setParent(view)
         imageView.view.resize(self.size, self.size)
         imageView.view.move(*self.position)
-
-        if self.viewName is 'CAMERA_LEFT':
-            # Rotate Multisense image/CAMERA_LEFT if the camera frame is rotated (e.g. for Valkyrie)
-            tf = robotStateModel.getLinkFrame(robotStateModel.getHeadLink())
-            roll = transformUtils.rollPitchYawFromTransform(tf)[0]
-            if np.isclose(np.abs(roll), np.pi, atol=1e-1):
-                imageView.setCameraRoll(0)
-
         imageView.view.show()
 
         if self.usePicker:


### PR DESCRIPTION
This flips the images directly in the ImageManager if the camera frame is rotated. Rotating at the lowest level is preferred compared to just rotating the camera when displaying it (and cascades through every use of the image). Tested with val2 and v5.