### PR TITLE
Deactivate Driving Planner (was throwing errors)

### DIFF
--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -161,6 +161,7 @@ useRandomWalk = True
 useCOPMonitor = True
 useCourseModel = False
 useMappingPanel = True
+useDrivingPlanner = False
 
 poseCollection = PythonQt.dd.ddSignalMap()
 costCollection = PythonQt.dd.ddSignalMap()
@@ -462,7 +463,7 @@ if usePlanning:
                                                                        teleopJointController, navigationPanel, cameraview, jointLimitChecker)
     continuousWalkingTaskPanel = continuouswalkingdemo.ContinuousWalkingTaskPanel(continuouswalkingDemo)
 
-    useDrivingPlanner = drivingplanner.DrivingPlanner.isCompatibleWithConfig()
+    #useDrivingPlanner = drivingplanner.DrivingPlanner.isCompatibleWithConfig()
     if useDrivingPlanner:
         drivingPlannerPanel = drivingplanner.DrivingPlannerPanel(robotSystem)
 


### PR DESCRIPTION
Driving Planner is throwing warnings/errors on each director launch. Given that we are probably not going to drive with the robots any time soon, does it make sense to disable it from loading by default?