### PR TITLE
Proposal to add a second robot for unit tests

### DIFF
--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -38,11 +38,13 @@ set(python_tests_robot
   testAmazonPod.py
 )
 
-# Tests are run by default on Valkyrie (val2)
+# Tests are run by default on the default robot
 #
-# If intending to test Atlas only, please set _extra_args -v5
-# Tests can also be run for both Atlas and Valkyrie by setting an additional
-#  _extra_args_2 -v5
+# If intending to test on a particular robot only, please set _extra_args to the
+# director argument for that robot.
+#
+# Tests can also be run on multiple (currently 2) robots by setting an additional
+#  _extra_args_2 to the director argument for the second robot to test.
 
 # these tests are tested on Atlas v5 robot model ONLY
 set(testKinematicPose_extra_args -v5)

--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -55,6 +55,15 @@ macro(add_python_test name label)
   add_test(${test_name} ${python_exe} ${CMAKE_CURRENT_SOURCE_DIR}/${name} ${python_test_args} ${${base_name}_extra_args})
   set_property(TEST ${test_name} PROPERTY ENVIRONMENT ${python_coverage_environment_arg})
   set_property(TEST ${test_name} PROPERTY LABELS ${label})
+
+  # Check whether a second test case has been defined
+  # TODO: replace with a loop over _extra_args_{n}
+  if(DEFINED ${base_name}_extra_args_2)
+    set(test_name test_${base_name}_2)
+    add_test(${test_name} ${python_exe} ${CMAKE_CURRENT_SOURCE_DIR}/${name} ${python_test_args} ${${base_name}_extra_args_2})
+    set_property(TEST ${test_name} PROPERTY ENVIRONMENT ${python_coverage_environment_arg})
+    set_property(TEST ${test_name} PROPERTY LABELS ${label})
+  endif()
 endmacro()
 
 

--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -44,14 +44,14 @@ set(python_tests_robot
 # director argument for that robot.
 #
 # Tests can also be run on multiple robots by setting an additional
-# _extra_args_{n} to the director argument for the n-th robot to test.
+# _extra_args_{n} to the director argument for the n-th robot to test, n >= 2.
 
 # these tests are tested on Atlas v5 robot model ONLY
 set(testKinematicPose_extra_args -v5)
 
 # these tests use both Atlas v5 and Valkyrie
-set(testTeleopPanel_extra_args_1 -v5)
-set(testContinuousWalking_extra_args_1 -v5)
+set(testTeleopPanel_extra_args_2 -v5)
+set(testContinuousWalking_extra_args_2 -v5)
 
 
 set(python_test_args
@@ -68,7 +68,7 @@ macro(add_python_test name label)
   set_property(TEST ${test_name} PROPERTY LABELS ${label})
 
   # Check whether additional test cases have been defined
-  set(n 1)
+  set(n 2)
   while(DEFINED ${base_name}_extra_args_${n})
     set(test_name test_${base_name}_${n})
     add_test(${test_name} ${python_exe} ${CMAKE_CURRENT_SOURCE_DIR}/${name} ${python_test_args} ${${base_name}_extra_args_${n}})

--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -38,10 +38,19 @@ set(python_tests_robot
   testAmazonPod.py
 )
 
-# these tests use Atlas v5 robot model
+# Tests are run by default on Valkyrie (val2)
+#
+# If intending to test Atlas only, please set _extra_args -v5
+# Tests can also be run for both Atlas and Valkyrie by setting an additional
+#  _extra_args_2 -v5
+
+# these tests are tested on Atlas v5 robot model ONLY
 set(testKinematicPose_extra_args -v5)
-set(testTeleopPanel_extra_args -v5)
-set(testContinuousWalking_extra_args -v5)
+
+# these tests use both Atlas v5 and Valkyrie
+set(testTeleopPanel_extra_args_2 -v5)
+set(testContinuousWalking_extra_args_2 -v5)
+
 
 set(python_test_args
   --testing --data-dir ${CMAKE_SOURCE_DIR}/../../../drc-testing-data --output-dir ${CMAKE_BINARY_DIR}/Testing/Temporary

--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -43,15 +43,15 @@ set(python_tests_robot
 # If intending to test on a particular robot only, please set _extra_args to the
 # director argument for that robot.
 #
-# Tests can also be run on multiple (currently 2) robots by setting an additional
-#  _extra_args_2 to the director argument for the second robot to test.
+# Tests can also be run on multiple robots by setting an additional
+# _extra_args_{n} to the director argument for the n-th robot to test.
 
 # these tests are tested on Atlas v5 robot model ONLY
 set(testKinematicPose_extra_args -v5)
 
 # these tests use both Atlas v5 and Valkyrie
-set(testTeleopPanel_extra_args_2 -v5)
-set(testContinuousWalking_extra_args_2 -v5)
+set(testTeleopPanel_extra_args_1 -v5)
+set(testContinuousWalking_extra_args_1 -v5)
 
 
 set(python_test_args
@@ -67,14 +67,15 @@ macro(add_python_test name label)
   set_property(TEST ${test_name} PROPERTY ENVIRONMENT ${python_coverage_environment_arg})
   set_property(TEST ${test_name} PROPERTY LABELS ${label})
 
-  # Check whether a second test case has been defined
-  # TODO: replace with a loop over _extra_args_{n}
-  if(DEFINED ${base_name}_extra_args_2)
-    set(test_name test_${base_name}_2)
-    add_test(${test_name} ${python_exe} ${CMAKE_CURRENT_SOURCE_DIR}/${name} ${python_test_args} ${${base_name}_extra_args_2})
+  # Check whether additional test cases have been defined
+  set(n 1)
+  while(DEFINED ${base_name}_extra_args_${n})
+    set(test_name test_${base_name}_${n})
+    add_test(${test_name} ${python_exe} ${CMAKE_CURRENT_SOURCE_DIR}/${name} ${python_test_args} ${${base_name}_extra_args_${n}})
     set_property(TEST ${test_name} PROPERTY ENVIRONMENT ${python_coverage_environment_arg})
     set_property(TEST ${test_name} PROPERTY LABELS ${label})
-  endif()
+    math(EXPR n "${n}+1")
+  endwhile()
 endmacro()
 
 


### PR DESCRIPTION
Follow up from discussion https://github.com/RobotLocomotion/director/pull/173#issuecomment-178768268:

Proposal to add a check whether _extra_args_2 is set. If it is, then a second test is added with those arguments instead of the _extra_args. Note, it continues to assume Valkyrie by default and will only disable running the test on Valkyrie if _extra_args (without _2) is set/overwritten with the corresponding argument.

Pat, is there a way to (wildcard) loop over all _extra_args_{n} without having to set an integer and try increasing it in a for loop until it is not defined anymore? 

If this is OK, should we add all relevant robot tests to be run for both Valkyrie and Atlas v5?