### PR TITLE
Work without headLink

### DIFF
--- a/src/python/director/roboturdf.py
+++ b/src/python/director/roboturdf.py
@@ -106,7 +106,7 @@ class RobotModelItem(om.ObjectModelItem):
             return None
 
     def getHeadLink(self):
-        return drcargs.getDirectorConfig()['headLink'] if 'headLink' in drcargs.getDirectorConfig() else None
+        return drcargs.getDirectorConfig().get('headLink')
 
     def getLinkContactPoints(self, linkName):
         pts = self.model.getBodyContactPoints(linkName)

--- a/src/python/director/roboturdf.py
+++ b/src/python/director/roboturdf.py
@@ -106,7 +106,7 @@ class RobotModelItem(om.ObjectModelItem):
             return None
 
     def getHeadLink(self):
-        return drcargs.getDirectorConfig()['headLink']
+        return drcargs.getDirectorConfig()['headLink'] if 'headLink' in drcargs.getDirectorConfig() else None
 
     def getLinkContactPoints(self, linkName):
         pts = self.model.getBodyContactPoints(linkName)


### PR DESCRIPTION
Currently when the directorConfig does not have a headLink, director fails to fully load since cameraview is trying to load one. This will return None if there is no headLink in the director config.