### PR TITLE
Lidar aggregation and visualization

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -164,6 +164,24 @@ if (USE_LCM)
     wrapped_methods_lcm.txt
   )
 
+  if (USE_DRAKE)
+
+    set(moc_srcs)
+    qt4_wrap_cpp(moc_srcs
+      ddLidarPointCloudLCM.h
+    )
+
+    list(APPEND srcs
+      ${moc_srcs}
+      ddLidarPointCloudLCM.cpp
+    )
+
+    list(APPEND wrap_files
+      wrapped_methods_drake_lcm.txt
+    )
+
+  endif()
+
 endif()
 
 if (USE_DRC)

--- a/src/app/ddLidarPointCloudLCM.cpp
+++ b/src/app/ddLidarPointCloudLCM.cpp
@@ -1,0 +1,151 @@
+#include "ddLidarPointCloudLCM.h"
+
+#include "ddLCMSubscriber.h"
+#include "ddLCMThread.h"
+
+#include <lcmtypes/drake/lcmt_lidar_data.hpp>
+
+#include <vtkCellArray.h>
+#include <vtkNew.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+
+#include <QMutexLocker>
+
+namespace
+{
+  struct SensorData
+  {
+    QMap<float, drake::lcmt_lidar_data> data;
+    float lastAngle;
+  };
+}
+
+//-----------------------------------------------------------------------------
+class ddLidarPointCloudLCMPrivate
+{
+public:
+  ddLCMThread* lcm;
+  QHash<QString, SensorData> data;
+  QMutex mutex;
+};
+
+//-----------------------------------------------------------------------------
+ddLidarPointCloudLCM::ddLidarPointCloudLCM(QObject* parent)
+  : QObject{parent}, mD{new ddLidarPointCloudLCMPrivate}
+{
+}
+
+//-----------------------------------------------------------------------------
+ddLidarPointCloudLCM::~ddLidarPointCloudLCM()
+{
+}
+
+//-----------------------------------------------------------------------------
+void ddLidarPointCloudLCM::init(ddLCMThread* lcmThread, QString const& channel)
+{
+  mD->lcm = lcmThread;
+
+  auto const subscriber = new ddLCMSubscriber(channel, this);
+  subscriber->setNotifyAllMessagesEnabled(true);
+
+  connect(subscriber, SIGNAL(messageReceived(QByteArray, QString)),
+          this, SLOT(addData(QByteArray, QString)),
+          Qt::DirectConnection);
+
+  mD->lcm->addSubscriber(subscriber);
+}
+
+//-----------------------------------------------------------------------------
+QStringList ddLidarPointCloudLCM::channels() const
+{
+  QMutexLocker lock(&mD->mutex);
+  return mD->data.keys();
+}
+
+//-----------------------------------------------------------------------------
+QList<drake::lcmt_lidar_data> ddLidarPointCloudLCM::data(
+  QString const& channel) const
+{
+  QMutexLocker lock(&mD->mutex);
+  return mD->data.value(channel).data.values();
+}
+
+//-----------------------------------------------------------------------------
+void ddLidarPointCloudLCM::addData(
+  QByteArray const& data, QString const& channel)
+{
+  drake::lcmt_lidar_data message;
+  message.decode(data.data(), 0, data.size());
+
+  QMutexLocker lock(&mD->mutex);
+
+  auto& channelData = mD->data[channel];
+  if (channelData.data.isEmpty())
+  {
+    emit channelAdded(channel);
+  }
+  else
+  {
+    auto last = channelData.data.find(channelData.lastAngle);
+    auto const next = message.scan_angle;
+
+    if (message.scan_direction)
+    {
+      // TODO
+    }
+    else
+    {
+      // Start erasing after previous message
+      ++last;
+
+      if (next < channelData.lastAngle)
+      {
+        // Erase from after previous message to end of map
+        while (last != channelData.data.end())
+          last = channelData.data.erase(last);
+
+        // Continue erasing from start of map
+        last = channelData.data.begin();
+      }
+
+      // Erase up to insertion point for new message
+      while (last != channelData.data.end() && last.key() < next)
+        last = channelData.data.erase(last);
+    }
+  }
+
+  channelData.data.insert(message.scan_angle, message);
+  channelData.lastAngle = message.scan_angle;
+}
+
+//-----------------------------------------------------------------------------
+void ddLidarPointCloudLCM::extractPolyData(
+  QString const& channel, vtkPolyData* pd) const
+{
+  auto const currentData = data(channel);
+
+  vtkNew<vtkPoints> points;
+  vtkNew<vtkCellArray> verts;
+
+  auto totalPoints = vtkIdType{0};
+  for (auto const& scan : currentData)
+    totalPoints += scan.num_points;
+
+  points->Allocate(totalPoints);
+  verts->Allocate(totalPoints);
+
+  pd->SetPoints(points.GetPointer());
+  pd->SetVerts(verts.GetPointer());
+
+  for (auto const& scan : currentData)
+  {
+    for (auto const& p : scan.points)
+    {
+      auto const pointId = points->InsertNextPoint(p.x, p.y, p.z);
+      verts->InsertNextCell(1);
+      verts->InsertCellPoint(pointId);
+      // TODO field data
+    }
+  }
+}

--- a/src/app/ddLidarPointCloudLCM.h
+++ b/src/app/ddLidarPointCloudLCM.h
@@ -1,0 +1,74 @@
+#ifndef __ddLidarPointCloudLCM_h
+#define __ddLidarPointCloudLCM_h
+
+#include "ddAppConfigure.h"
+
+#include <QObject>
+
+namespace drake
+{
+  class lcmt_lidar_data;
+}
+
+class vtkPolyData;
+
+class ddLCMThread;
+
+class ddLidarPointCloudLCMPrivate;
+
+/// Helper class to aggregate data from a LIDAR stream.
+///
+/// This class collects data from one or more LIDAR data streams and aggregates
+/// it into a set of "recent" data, according to an invalidation policy. Per
+/// the policy, data is discarded based on the scan angle, when said angle
+/// falls within the range covered by consecutive recent data packets. For
+/// example, if the current collection includes scan angles \c 1, \c 2, \c 4,
+/// \c 6 and \c 8, with \c 1 being the most recently seen scan angle, and a new
+/// packet with scan angle \c 3 arrives, the old data with scan angle \c 2 will
+/// be discarded because it falls within the range \c 1 to \c 3. This policy
+/// accomodates both rotating sensors and bidirectional sweeping sensors.
+class DD_APP_EXPORT ddLidarPointCloudLCM : public QObject
+{
+  Q_OBJECT
+
+public:
+  ddLidarPointCloudLCM(QObject* parent = nullptr);
+  ~ddLidarPointCloudLCM();
+
+  void init(ddLCMThread* lcmThread,
+            QString const& channel = "DRAKE_POINTCLOUD_LIDAR_.*");
+
+  /// Return a list of all known channels.
+  QStringList channels() const;
+
+  /// Return all "current" data for the specified channel
+  ///
+  /// This function returns the collection of the most recent sensor data for
+  /// the specified channel, where "most recent" is determined by the data
+  /// aggregation invalidation policy. Refer to the class description for
+  /// details.
+  QList<drake::lcmt_lidar_data> data(QString const& channel) const;
+
+  /// Extract "current" data for the specified channel into a vtkPolyData
+  ///
+  /// This function "fills" a vtkPolyData with the collection of the most
+  /// recent sensor data for the specified channel. The vtkPolyData should be
+  /// empty, as this function will reset its points and vertices to new
+  /// objects. Non-positional data is stored as ancillary data arrays.
+  ///
+  /// \sa data(QString const&)
+  void extractPolyData(QString const&, vtkPolyData*) const;
+
+signals:
+  /// Emitted when a new channel is seen for the first time.
+  /// \sa channels()
+  void channelAdded(QString);
+
+protected slots:
+  void addData(QByteArray const& data, QString const& channel);
+
+protected:
+  QScopedPointer<ddLidarPointCloudLCMPrivate> const mD;
+};
+
+#endif

--- a/src/app/wrapped_methods_drake_lcm.txt
+++ b/src/app/wrapped_methods_drake_lcm.txt
@@ -1,0 +1,5 @@
+ddLidarPointCloudLCM::ddLidarPointCloudLCM(QObject*);
+void ddLidarPointCloudLCM::init(ddLCMThread*);
+void ddLidarPointCloudLCM::init(ddLCMThread*, QString const&);
+QStringList ddLidarPointCloudLCM::channels() const;
+void ddLidarPointCloudLCM::extractPolyData(QString const&, vtkPolyData*) const;

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -7,7 +7,7 @@ from director import transformUtils
 from director.debugVis import DebugData
 from director import ioUtils
 from director import filterUtils
-from director.shallowCopy import shallowCopy
+from director.timercallback import TimerCallback
 from director import vtkAll as vtk
 from director import visualization as vis
 
@@ -200,6 +200,44 @@ class Geometry(object):
             self.polyDataItem.shadowOn()
 
 
+class LidarSource(TimerCallback):
+
+    def __init__(self, view):
+        super(LidarSource, self).__init__(targetFps=30)
+
+        self.lidars = {}
+        self.view = view
+
+        lcm = lcmUtils.getGlobalLCMThread()
+        self.lidarAggregator = PythonQt.dd.ddLidarPointCloudLCM(lcm)
+
+        self.lidarAggregator.channelAdded.connect(self.addChannel)
+
+        self.channels = set(self.lidarAggregator.channels())
+        self.lidarAggregator.init(lcm)
+
+        self.callback = self._updateSource
+
+    def addChannel(self, channel):
+        self.channels.add(channel)
+
+    def _updateSource(self):
+        for channel in self.channels:
+            pd = vtk.vtkPolyData()
+            self.lidarAggregator.extractPolyData(channel, pd)
+
+            if not channel in self.lidars:
+                name = '%s lidar source' % channel
+                pdObj = vis.PolyDataItem(name, pd, self.view)
+                pdObj.setProperty('Visible', True)
+                pdObj.initialized = True
+                self.lidars[channel] = pdObj
+            else:
+                self.lidars[channel].setPolyData(pd)
+
+        self.view.render()
+
+
 class Link(object):
 
     def __init__(self, link):
@@ -219,6 +257,8 @@ class Link(object):
 class DrakeVisualizer(object):
 
     def __init__(self, view):
+
+        self.lidarSource = LidarSource(view)
 
         self.subscribers = []
         self.view = view
@@ -241,8 +281,10 @@ class DrakeVisualizer(object):
     def setEnabled(self, enabled):
         if enabled and not self.isEnabled():
             self._addSubscribers()
+            self.lidarSource.start()
         elif not enabled and self.isEnabled():
             self._removeSubscribers()
+            self.lidarSource.stop()
 
     def enable(self):
         self.setEnabled(True)

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -200,11 +200,9 @@ class Geometry(object):
             self.polyDataItem.shadowOn()
 
 
-class LidarSource(TimerCallback):
+class LidarSource(object):
 
     def __init__(self, view):
-        super(LidarSource, self).__init__(targetFps=30)
-
         self.lidars = {}
         self.view = view
 
@@ -216,7 +214,14 @@ class LidarSource(TimerCallback):
         self.channels = set(self.lidarAggregator.channels())
         self.lidarAggregator.init(lcm)
 
-        self.callback = self._updateSource
+        self.timer = TimerCallback(targetFps=30)
+        self.timer.callback = self._updateSource
+
+    def start(self):
+        self.timer.start()
+
+    def stop(self):
+        self.timer.stop()
 
     def addChannel(self, channel):
         self.channels.add(channel)


### PR DESCRIPTION
Add a utility class to aggregate lidar data. Modify drake-visualizer to use said class to visualize lidar data.

This doesn't handle bidirectional scans yet, nor does it copy all of the available data when building a `vtkPolyData` from the aggregated data. (On second thought, maybe this should be optional?)