### PR TITLE
use pointcloud_t type to transmit pointcloud data to director

### DIFF
--- a/src/app/ddPointCloudLCM.h
+++ b/src/app/ddPointCloudLCM.h
@@ -18,6 +18,7 @@
 
 #include <lcm/lcm-cpp.hpp>
 #include <lcmtypes/drc/pointcloud2_t.hpp>
+#include <lcmtypes/drc/pointcloud_t.hpp>
 
 class DD_APP_EXPORT ddPointCloudLCM : public QObject
 {
@@ -33,6 +34,7 @@ public:
 protected slots:
 
   void onPointCloudFrame(const QByteArray& data, const QString& channel);
+  void onPointCloud2Frame(const QByteArray& data, const QString& channel);
 
 
 protected:

--- a/src/python/director/pointcloudlcm.py
+++ b/src/python/director/pointcloudlcm.py
@@ -118,7 +118,7 @@ class PointCloudSource(TimerCallback):
             return
 
         sensorToLocalFused = vtk.vtkTransform()
-        self.queue.getTransform('VELODYNE', 'local', utime, sensorToLocalFused)
+        self.queue.getTransform('local', 'local', utime, sensorToLocalFused)
         p = filterUtils.transformPolyData(p,sensorToLocalFused)
         self.polyDataObj.setPolyData(p)
 


### PR DESCRIPTION
Adds the capability to use a pointcloud_t type to transmit PC data over lcm to director
https://www.dropbox.com/s/wfi9gr65pxe1ycy/2016-02-00-vtk-lcm-director.m4v?dl=0
This type (which mirrors ROS pointcloud message) but is not intertwined with PCL.

I havent time right not to show how this can support sending arbitrary attributes in the 'channels' field (r,g,b, intensity, range, scan_id, echo, etc...). But this can support all the fields of a vtk polydata for example.

If you look at https://github.com/openhumanoids/oh-distro/pull/65 it provides the type and an example  which:
- loads a vtk file
- publishes to lcm at POINTCLOUD
- can be displayed and rendered in director

The type message:
https://github.com/oh-dev/oh-distro/blob/mf-use-pointcloud-type/software/drc_lcmtypes/lcmtypes/drc_pointcloud_t.lcm

Prompted: https://github.com/RobotLocomotion/director/pull/189/ and https://github.com/RobotLocomotion/drake/pull/1699
