### PR TITLE
set skipped iterations factor to 10

### DIFF
--- a/src/vtk/DRCFilters/vtkPlaneSegmentation.cxx
+++ b/src/vtk/DRCFilters/vtkPlaneSegmentation.cxx
@@ -80,7 +80,7 @@ int vtkPlaneSegmentation::RequestData(
   // perform plane model fit
   planeseg::PlaneFitter fitter;
   fitter.setMaxDistance(this->DistanceThreshold);
-  fitter.setMaxIterations(this->MaxIterations);
+  fitter.setMaxIterations(this->MaxIterations, 10);
   fitter.setRefineUsingInliers(true);
   if (this->PerpendicularConstraintEnabled) {
     Eigen::Vector3f prior(this->PerpendicularAxis[0],


### PR DESCRIPTION
This allows more iterations when running plane fitting
with a perpendicularity constraint.  See:

https://github.com/openhumanoids/oh-distro-private/issues/2074#issuecomment-157876764