### PR TITLE
Image Widgets: auto-detect aspect ratio for ImageOverlayManager, make ImageWidget default

### DIFF
--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -416,6 +416,9 @@ class ImageWidget(object):
         self.imageName = imageName
         self.flip.SetInput(imageManager.getImage(imageName))
 
+    def setOpacity(self, opacity=1.0):
+        self.imageWidget.GetRepresentation().GetImageProperty().SetOpacity(opacity)
+
     def hide(self):
         self.imageWidget.Off()
 

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -395,6 +395,9 @@ class ImageWidget(object):
 
         self.imageWidget = vtk.vtkLogoWidget()
         rep = self.imageWidget.GetRepresentation()
+        rep.ProportionalResizeOn()
+        rep.SetPosition(0, 0.7)
+        rep.SetPosition2(0.3, 0.3) # Proportional size
         rep.GetImageProperty().SetOpacity(1.0)
         self.imageWidget.SetInteractor(self.view.renderWindow().GetInteractor())
 

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -395,23 +395,42 @@ class ImageWidget(object):
         self.initialized = False
 
         self.imageWidget = vtk.vtkLogoWidget()
-        rep = self.imageWidget.GetRepresentation()
-        rep.ProportionalResizeOn()
-        rep.SetPosition(0, 0.7)
-        rep.SetPosition2(0.3, 0.3) # Proportional size
-        rep.GetImageProperty().SetOpacity(1.0)
+        imageRep = self.imageWidget.GetRepresentation()
+        self.imageWidget.ResizableOff()
+        self.imageWidget.SelectableOn()
+
+        imageRep.GetImageProperty().SetOpacity(1.0)
         self.imageWidget.SetInteractor(self.view.renderWindow().GetInteractor())
 
         self.flip = vtk.vtkImageFlip()
         self.flip.SetFilteredAxis(1)
         self.flip.SetInput(imageManager.getImage(imageName))
-        rep.SetImage(self.flip.GetOutput())
+        imageRep.SetImage(self.flip.GetOutput())
 
         self.timerCallback = TimerCallback()
         self.timerCallback.targetFps = 60
         self.timerCallback.callback = self.updateView
         self.timerCallback.start()
 
+        self.initialized = False
+
+    def setWidgetSize(self, desiredWidth=400):
+        viewWidth, viewHeight = self.view.width, self.view.height
+        defaultImageAspectRatio = 4/3.
+        imageWidth, imageHeight = desiredWidth, desiredWidth/defaultImageAspectRatio
+
+        rep = self.imageWidget.GetBorderRepresentation()
+        rep.SetShowBorderToOff()
+        coord = rep.GetPositionCoordinate()
+        coord2 = rep.GetPosition2Coordinate()
+        coord.SetCoordinateSystemToDisplay()
+        coord2.SetCoordinateSystemToDisplay()
+        coord.SetValue(0, viewHeight-imageHeight)
+        coord2.SetValue(imageWidth, imageHeight)
+
+        if self.visible:
+            self.hide()
+            self.show()
 
     def setImage(self, imageName):
         self.imageName = imageName
@@ -425,6 +444,10 @@ class ImageWidget(object):
         self.imageWidget.Off()
 
     def show(self):
+        if not self.initialized:
+            self.setWidgetSize(400)
+            self.initialized = True
+
         self.visible = True
         self.imageWidget.On()
 

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -428,9 +428,7 @@ class ImageWidget(object):
         coord.SetValue(0, viewHeight-imageHeight)
         coord2.SetValue(imageWidth, imageHeight)
 
-        if self.visible:
-            self.hide()
-            self.show()
+        self.view.render()
 
     def setImage(self, imageName):
         self.imageName = imageName

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -412,6 +412,10 @@ class ImageWidget(object):
         self.timerCallback.start()
 
 
+    def setImage(self, imageName):
+        self.imageName = imageName
+        self.flip.SetInput(imageManager.getImage(imageName))
+
     def hide(self):
         self.imageWidget.Off()
 

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -385,10 +385,11 @@ class CameraView(object):
 
 class ImageWidget(object):
 
-    def __init__(self, imageManager, imageName, view):
+    def __init__(self, imageManager, imageName, view, visible=True):
         self.view = view
         self.imageManager = imageManager
         self.imageName = imageName
+        self.visible = visible
 
         self.updateUtime = 0
         self.initialized = False
@@ -420,9 +421,11 @@ class ImageWidget(object):
         self.imageWidget.GetRepresentation().GetImageProperty().SetOpacity(opacity)
 
     def hide(self):
+        self.visible = False
         self.imageWidget.Off()
 
     def show(self):
+        self.visible = True
         self.imageWidget.On()
 
     def updateView(self):
@@ -432,7 +435,7 @@ class ImageWidget(object):
 
         currentUtime = self.imageManager.updateImage(self.imageName)
         if currentUtime != self.updateUtime:
-            if not self.initialized:
+            if not self.initialized and self.visible:
                 self.show()
                 self.initialized = True
 

--- a/src/python/director/cameraview.py
+++ b/src/python/director/cameraview.py
@@ -429,7 +429,6 @@ class ImageWidget(object):
         self.imageWidget.On()
 
     def updateView(self):
-
         if not self.view.isVisible():
             return
 

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -709,8 +709,12 @@ class ImageOverlayManager(object):
         self.imageSize = [640, 480]
         self.imageAspectRatio = 4/3.
 
-    def show(self):
+    def setWidth(self, width):
+        self.desiredWidth = width
+        self.hide()
+        self.show()
 
+    def show(self):
         if self.imageView:
             return
 

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -699,8 +699,8 @@ class ImageOverlayManager(object):
 
     def __init__(self):
         self.viewName = 'CAMERA_LEFT'
-        #self.viewName = 'KINECT_RGB'
-        self.size = 400
+        self.desiredWidth = 400
+        self.size = [self.desiredWidth, self.desiredWidth/(4/3.)]
         self.position = [0, 0]
         self.usePicker = False
         self.imageView = None
@@ -718,7 +718,7 @@ class ImageOverlayManager(object):
 
         imageView.view.hide()
         imageView.view.setParent(view)
-        imageView.view.resize(self.size, self.size)
+        imageView.view.resize(*self.size)
         imageView.view.move(*self.position)
         imageView.view.show()
 

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -1,6 +1,8 @@
 # This script is executed in the main console namespace so
 # that all the variables defined here become console variables.
 
+from __future__ import division
+
 import director
 from director import irisdriver
 

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -761,6 +761,9 @@ imageWidget = cameraview.ImageWidget(cameraview.imageManager, 'CAMERA_LEFT', vie
 imageViewHandler = ToggleImageViewHandler(imageOverlayManager)
 showImageOverlay = imageOverlayManager.show
 hideImageOverlay = imageOverlayManager.hide
+showImageWidget = imageWidget.show
+hideImageWidget = imageWidget.hide
+setImageWidgetSource = imageWidget.setImage
 
 screengrabberpanel.init(view)
 framevisualization.init(view)

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -758,7 +758,7 @@ class ToggleImageViewHandler(object):
 
 imageOverlayManager = ImageOverlayManager()
 imageWidget = cameraview.ImageWidget(cameraview.imageManager, 'CAMERA_LEFT', view, visible=False)
-imageViewHandler = ToggleImageViewHandler(imageOverlayManager)
+imageViewHandler = ToggleImageViewHandler(imageWidget)
 showImageOverlay = imageOverlayManager.show
 hideImageOverlay = imageOverlayManager.hide
 showImageWidget = imageWidget.show

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -723,7 +723,7 @@ class ImageOverlayManager(object):
         self._prevParent = imageView.view.parent()
 
         imageExtent = cameraview.imageManager.images[self.viewName].GetExtent()
-        if imageExtent[1] != -1 or imageExtent[3] != -1:
+        if imageExtent[1] != -1 and imageExtent[3] != -1:
             self.imageSize = [imageExtent[1]+1, imageExtent[3]+1]
             self.imageAspectRatio = self.imageSize[0] / self.imageSize[1]
             self.size = [self.desiredWidth, self.desiredWidth / self.imageAspectRatio]

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -152,7 +152,6 @@ useDrakeVisualizer = True
 useNavigationPanel = True
 useFootContactVis = True
 useFallDetectorVis = True
-useImageWidget = False
 useCameraFrustumVisualizer = True
 useControllerRate = True
 useForceDisplay = False
@@ -687,11 +686,6 @@ if useDataFiles:
         if polyData:
             vis.showPolyData(polyData, os.path.basename(filename))
 
-
-if useImageWidget:
-    imageWidget = cameraview.ImageWidget(cameraview.imageManager, 'CAMERA_LEFT', view)
-    #imageWidget = cameraview.ImageWidget(cameraview.imageManager, 'KINECT_RGB', view)
-
 if useCameraFrustumVisualizer and cameraview.CameraFrustumVisualizer.isCompatibleWithConfig():
     cameraFrustumVisualizer = cameraview.CameraFrustumVisualizer(robotStateModel, cameraview.imageManager, 'CAMERA_LEFT')
 
@@ -763,6 +757,7 @@ class ToggleImageViewHandler(object):
 
 
 imageOverlayManager = ImageOverlayManager()
+imageWidget = cameraview.ImageWidget(cameraview.imageManager, 'CAMERA_LEFT', view, visible=False)
 imageViewHandler = ToggleImageViewHandler(imageOverlayManager)
 showImageOverlay = imageOverlayManager.show
 hideImageOverlay = imageOverlayManager.hide

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -706,6 +706,8 @@ class ImageOverlayManager(object):
         self.imageView = None
         self.imagePicker = None
         self._prevParent = None
+        self.imageSize = [640, 480]
+        self.imageAspectRatio = 4/3.
 
     def show(self):
 
@@ -715,6 +717,12 @@ class ImageOverlayManager(object):
         imageView = cameraview.views[self.viewName]
         self.imageView = imageView
         self._prevParent = imageView.view.parent()
+
+        imageExtent = cameraview.imageManager.images[self.viewName].GetExtent()
+        if imageExtent[1] != -1 or imageExtent[3] != -1:
+            self.imageSize = [imageExtent[1]+1, imageExtent[3]+1]
+            self.imageAspectRatio = self.imageSize[0] / self.imageSize[1]
+            self.size = [self.desiredWidth, self.desiredWidth / self.imageAspectRatio]
 
         imageView.view.hide()
         imageView.view.setParent(view)


### PR DESCRIPTION
This PR includes two changes to the ImageOverlayManager and ImageWidget:

1. ImageOverlayManager now auto-detects the aspect ratio of the image to be displayed so that there is no more black borders at the top and bottom of the image
2. ImageWidget can be initialised hidden
3. ImageWidget is now the default for the toggle button in the user interface. The rationale behind this is that we often record videos with an image overlay on only to realise afterwards that it's a black spot instead of the video
4. The source of an ImageWidget can be changed without having to re-initialise the object

Pat, there are two remaining issues that I'd like to get your input on:

1. ImageWidget has unused padding left and right of the image, yet I could not find the right vtk command to get rid of it
2. ImageOverlayManager had a better image quality than ImageWidget does

Thanks :)