### PR TITLE
use a minimum bounding box algorithm to recover the frame of a table

### DIFF
--- a/src/python/director/perception.py
+++ b/src/python/director/perception.py
@@ -344,15 +344,21 @@ class MultiSenseSource(TimerCallback):
 
     @staticmethod
     def setNeckPitch(neckPitchDegrees):
-        '''
-        Currently hard-coded for Atlas to match previous functionality
-        '''
         assert neckPitchDegrees <= 90 and neckPitchDegrees >= -90
+
+        jointGroups = drcargs.getDirectorConfig()['teleopJointGroups']
+        jointGroupNeck = filter(lambda group: group['name'] == 'Neck', jointGroups)
+        if (len(jointGroupNeck) == 1):
+            neckJoints = jointGroupNeck[0]['joints']
+        else:
+            return
+
+        # Assume first neck joint is the pitch joint
         m = lcmbotcore.joint_angles_t()
         m.utime = getUtime()
         m.num_joints = 1
-        m.joint_name = [ "neck_ay" ]
-        m.joint_position = math.radians(neckPitchDegrees)
+        m.joint_name = [ neckJoints[0] ]
+        m.joint_position = [math.radians(neckPitchDegrees)]
         lcmUtils.publish('DESIRED_NECK_ANGLES', m)
 
 

--- a/src/python/tests/testContinuousWalking.py
+++ b/src/python/tests/testContinuousWalking.py
@@ -32,7 +32,7 @@ def processSingleBlock(robotStateModel, whichFile=0):
 
     standingFootName = cwdemo.ikPlanner.leftFootLink
     standingFootFrame = robotStateModel.getLinkFrame(standingFootName)
-    cwdemo.findMinimumBoundingRectangle(polyData, standingFootFrame)
+    segmentation.findMinimumBoundingRectangle(polyData, standingFootFrame)
 
 
 def processSnippet():


### PR DESCRIPTION
- stops using getOrientedBoundingBox (vtkAnnotateOBBs). reuses code from continuous walking block segmentation. in particular gives more reliable standing frame. still needs some improvement but works better than previous approach

edgePoint is no longer required for segmentTableEdge, but haven't changed it in argument.

Before (can actually be much worse):
![before](https://cloud.githubusercontent.com/assets/6404227/14102213/11edccfc-f591-11e5-99d4-976b547a320c.png)

After:
![after](https://cloud.githubusercontent.com/assets/6404227/14102217/1744f8d8-f591-11e5-8157-13dcf8c6c955.png)