### PR TITLE
Fix ik matlab communication

### DIFF
--- a/src/python/director/drcargs.py
+++ b/src/python/director/drcargs.py
@@ -74,8 +74,6 @@ class DRCArgParser(object):
 
         parser.add_argument('--matlab-host', type=str, help='Hostname to use external matlab server')
 
-        parser.add_argument('-exo', '--exo', action='store_true', dest='exo', help='Publish plannig requests to external planner instead of Drake')
-
         directorConfig = parser.add_mutually_exclusive_group(required=False)
         directorConfig.add_argument('-v3', '--atlas_v3', dest='directorConfigFile',
                             action='store_const',

--- a/src/python/director/ikplanner.py
+++ b/src/python/director/ikplanner.py
@@ -68,7 +68,7 @@ class ConstraintSet(object):
         if self.ikPlanner.planningMode == 'exotica':
             self.endPose, self.info = self.ikPlanner.plannerPub.processIK(self.constraints, nominalPoseName=nominalPoseName, seedPoseName=seedPoseName)
             return self.endPose, self.info
-        elif self.ikPlanner.planningMode == 'drake' and self.ikPlanner.pushToMatlab:
+        elif self.ikPlanner.planningMode == 'drake':
             ikParameters = self.ikPlanner.mergeWithDefaultIkParameters(self.ikParameters)
 
             self.endPose, self.info = self.ikPlanner.ikServer.runIk(self.constraints, ikParameters, nominalPostureName=nominalPoseName, seedPostureName=seedPoseName)
@@ -1357,7 +1357,7 @@ class IKPlanner(object):
 
         if self.planningMode == 'exotica':
             self.lastManipPlan, info = self.plannerPub.processTraj(constraints,endPoseName=poseEnd, nominalPoseName=nominalPoseName,seedPoseName=poseStart, additionalTimeSamples=self.additionalTimeSamples)
-        elif self.planningMode == 'drake' and self.pushToMatlab:
+        elif self.planningMode == 'drake':
             ikParameters = self.mergeWithDefaultIkParameters(ikParameters)
             listener = self.getManipPlanListener()
             info = self.ikServer.runIkTraj(constraints, poseStart=poseStart, poseEnd=poseEnd, nominalPose=nominalPoseName, ikParameters=ikParameters, timeSamples=timeSamples, additionalTimeSamples=self.additionalTimeSamples,

--- a/src/python/director/motionplanningpanel.py
+++ b/src/python/director/motionplanningpanel.py
@@ -121,16 +121,16 @@ class MotionPlanningPanel(object):
     def checkFinalPosePlanningMode(self):
         algorithm = self.getComboText(self.ui.fpAlgComboBox)
         if 'Drake' in algorithm:
-            self.ikPlanner.pushToMatlab = True
+            self.ikPlanner.planningMode = 'drake'
         elif 'Exotica' in algorithm:
-            self.ikPlanner.pushToMatlab = False
+            self.ikPlanner.planningMode = 'exotica'
         
     def checkReachingPlanningMode(self):
         algorithm = self.getComboText(self.ui.mpAlgComboBox)
         if 'Drake' in algorithm:
-            self.ikPlanner.pushToMatlab = True
+            self.ikPlanner.planningMode = 'drake'
         elif 'Exotica' in algorithm:
-            self.ikPlanner.pushToMatlab = False
+            self.ikPlanner.planningMode = 'exotica'
             
     def onHandChanged(self, combo):
         if self.ui.mpModeButton.checked:

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -1086,12 +1086,6 @@ if 'useKuka' in drcargs.getDirectorConfig()['userConfig']:
     #ikPlanner.fixedBaseArm = True
     #showImageOverlay()
 
-
-if 'exo' in drcargs.args():
-    if (drcargs.args().exo):
-        ikPlanner.pushToMatlab = False
-
-
 def roomMap():
     mappingPanel.onStartMappingButton()
     t = mappingdemo.MappingDemo(robotStateModel, playbackRobotModel,


### PR DESCRIPTION
@patmarion  Sorry for the late reply. The issue in #235 #236 is because pushToMatlab is used in a conflict way. It is used to indicate both 'push to matlab or not' and 'use matlab or exotica to solve IK'. I added a new variable to select the planning mode (for now, drake or exotica). The pushToMatlab var is now only used to indicate whether push things to matlab.