### PR TITLE
Add findOutputDevice to midi.py

### DIFF
--- a/src/python/director/midi.py
+++ b/src/python/director/midi.py
@@ -37,11 +37,17 @@ def printDevices():
 
 
 def findInputDevice(deviceName):
-
     init()
     for deviceId in xrange(pypm.CountDevices()):
         interf, name, inp, outp, opened = pypm.GetDeviceInfo(deviceId)
         if inp and (deviceName in name):
+                return deviceId
+
+def findOutputDevice(deviceName):
+    init()
+    for deviceId in xrange(pypm.CountDevices()):
+        interf, name, inp, outp, opened = pypm.GetDeviceInfo(deviceId)
+        if outp and (deviceName in name):
                 return deviceId
 
 


### PR DESCRIPTION
Mirroring what's there for findInputDevice

By the way, was there a specific reason not to use the python-midi package that can be installed via pip?