### PR TITLE
mark double click event as consumed after toggling footstep widget

### DIFF
--- a/src/python/director/robotviewbehaviors.py
+++ b/src/python/director/robotviewbehaviors.py
@@ -581,9 +581,11 @@ class RobotViewEventFilter(ViewEventFilter):
 
         useHorizontalWidget =  (event.modifiers() == QtCore.Qt.ShiftModifier)
         if toggleFootstepWidget(displayPoint, self.view, useHorizontalWidget):
+            self.consumeEvent()
             return
 
         if robotLinkSelector and robotLinkSelector.selectLink(displayPoint, self.view):
+            self.consumeEvent()
             return
 
     def onKeyPress(self, event):


### PR DESCRIPTION
i broke this when splitting view behaviors into robot view behaviors