### PR TITLE
add vrml loading support to file menu of drake-visualizer

### DIFF
--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -567,7 +567,20 @@ class DrakeVisualizerApp():
     def _showErrorMessage(self, title, message):
         QtGui.QMessageBox.warning(self.mainWindow, title, message)
 
+
+    def onOpenVrml(self, filename):
+        meshes, color = ioUtils.readVrml(filename)
+        folder = om.getOrCreateContainer(os.path.basename(filename), parentObj=om.getOrCreateContainer('files'))
+        for i, pair in enumerate(zip(meshes, color)):
+            mesh, color = pair
+            obj = vis.showPolyData(mesh, 'mesh %d' % i, color=color, parent=folder)
+            vis.addChildFrame(obj)
+
     def _openGeometry(self, filename):
+
+        if filename.lower().endswith('wrl'):
+            self.onOpenVrml(filename)
+            return
 
         polyData = ioUtils.readPolyData(filename)
 
@@ -578,7 +591,7 @@ class DrakeVisualizerApp():
         vis.showPolyData(polyData, os.path.basename(filename), parent='files')
 
     def _onOpenDataFile(self):
-        fileFilters = "Data Files (*.obj *.ply *.stl *.vtk *.vtp)";
+        fileFilters = "Data Files (*.obj *.ply *.stl *.vtk *.vtp *.wrl)";
         filename = QtGui.QFileDialog.getOpenFileName(self.mainWindow, "Open...", self._getOpenDataDirectory(), fileFilters)
         if not filename:
             return


### PR DESCRIPTION
todo- re-use the loading code in actionhandlers.py.
currently this file can't be imported because of lcmtype
dependencies but this can be resolved soon.