### PR TITLE
support ellipsoids in debugVis and drakevisualizer

### DIFF
--- a/src/python/director/debugVis.py
+++ b/src/python/director/debugVis.py
@@ -153,6 +153,28 @@ class DebugData(object):
         transformFilter.Update()
         self.addPolyData(transformFilter.GetOutput())
 
+    def addEllipsoid(self, center, radii, color=[1,1,1], alpha=1.0, resolution=24):
+        """
+        Add an ellipsoid centered at [center] with x, y, and z principal axis radii given by
+        radii = [x_scale, y_scale, z_scale]
+        """
+        sphere = vtk.vtkSphereSource()
+        sphere.SetCenter([0,0,0])
+        sphere.SetThetaResolution(resolution)
+        sphere.SetPhiResolution(resolution)
+        sphere.SetRadius(1.0)
+        sphere.Update()
+
+        transform = vtk.vtkTransform()
+        transform.Translate(center)
+        transform.Scale(radii)
+
+        transformFilter = vtk.vtkTransformPolyDataFilter()
+        transformFilter.SetTransform(transform)
+        transformFilter.SetInputConnection(sphere.GetOutputPort())
+        transformFilter.Update()
+        self.addPolyData(transformFilter.GetOutput())
+
     def getPolyData(self):
 
         if self.append.GetNumberOfInputConnections(0):

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -56,6 +56,12 @@ class Geometry(object):
             d.addSphere(center=(0,0,-length/2.0), radius=radius)
             return d.getPolyData()
 
+        elif hasattr(lcmdrake.lcmt_viewer_geometry_data, "ELLIPSOID") and geom.type == lcmdrake.lcmt_viewer_geometry_data.ELLIPSOID:
+            d = DebugData()
+            radii = geom.float_data[0:3]
+            d.addEllipsoid(center=(0,0,0), radii=radii)
+            return d.getPolyData()
+
         raise Exception('Unsupported geometry type: %s' % geom.type)
 
     @staticmethod


### PR DESCRIPTION
@peteflorence thanks for the code!

This will be useful for, e.g. drawing inertial ellipsoids without resorting to LCMGL hacks. It will require an update to the list of enums in the corresponding Drake LCM type, but that change doesn't actually affect the LCM fingerprint so this should be fully backwards-compatible. 