### PR TITLE
update readme for new vtk5 tap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ The dependencies can be installed on Mac using `Homebrew <http://brew.sh/>`_:
 
 ::
 
+    brew tap robotlocomotion/director
     brew tap homebrew/science
     brew tap homebrew/python
     brew install cmake

--- a/distro/travis/before_install.sh
+++ b/distro/travis/before_install.sh
@@ -17,8 +17,8 @@ make_vtk_homebrew_bottle()
 install_vtk_homebrew_bottle()
 {
   wget https://www.dropbox.com/s/r0o7b3zrv6een6o/vtk5-5.10.1_2.mavericks.bottle.1.tar.gz
-  brew tap homebrew/science
   brew tap rdeits/director
+  brew tap homebrew/science
   brew install vtk5-5.10.1_2.mavericks.bottle.1.tar.gz
 }
 


### PR DESCRIPTION
Note that I'm using the RobotLocomotion/director tap for the Readme (since that'll be the right thing going forward), but I'm using rdeits/director within Travis. That's because I've got exactly the version of the VTK5 recipe that matches the bottled version, so it will keep Travis happy until we make a new bottle. 