### PR TITLE
fixes issue with joint limit checker

### DIFF
--- a/src/python/director/teleoppanel.py
+++ b/src/python/director/teleoppanel.py
@@ -888,7 +888,8 @@ class JointLimitChecker(object):
         choice = msgBox.exec_()
 
         if choice == 0: # No
-            self.stop()
+            # don't do anything except close the dialog window
+            return
         elif choice == 2: # Yes, then auto
             self.automaticallyExtendLimits = True
             self.extendJointLimitsAsExceeded(limitData)


### PR DESCRIPTION
Previously pressing the extending limits "No" button hid the Red button
and disabled the checker thereafter. This made it impossible to
subsequently plan when the robot was outside the limits.

this change merely closes the dialog. the user can still press 'Yes'
afterwards