### PR TITLE
Fix widget footstep goal computation

### DIFF
--- a/src/python/director/robotviewbehaviors.py
+++ b/src/python/director/robotviewbehaviors.py
@@ -191,9 +191,9 @@ def newWalkingGoal(displayPoint, view):
     t = vtk.mutable(0.0)
     vtk.vtkPlane.IntersectWithLine(worldPt1, worldPt2, groundNormal, groundOrigin, t, selectedGroundPoint)
 
-    footFrame.Translate(np.array(selectedGroundPoint) - np.array(footFrame.GetPosition()))
+    walkingTarget = transformUtils.frameFromPositionAndRPY(selectedGroundPoint, np.array(footFrame.GetOrientation()))
 
-    footstepsdriverpanel.panel.onNewWalkingGoal(footFrame)
+    footstepsdriverpanel.panel.onNewWalkingGoal(walkingTarget)
 
 
 def toggleFootstepWidget(displayPoint, view, useHorizontalWidget=False):


### PR DESCRIPTION
The translate does not seep to work because selectedGroundPoint and footFrame are in different coordinate frames.