### PR TITLE
Clamp planning start pose to joint limits

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -75,6 +75,7 @@ set(python_files
   director/openscope.py
   director/packagepath.py
   director/perception.py
+  director/planningutils.py
   director/planplayback.py
   director/playbackpanel.py
   director/pointcloudlcm.py

--- a/src/python/director/continuouswalkingdemo.py
+++ b/src/python/director/continuouswalkingdemo.py
@@ -86,7 +86,7 @@ class ContinousWalkingDemo(object):
                                   [0.5*FOOT_WIDTH, -0.5*FOOT_WIDTH, 0.5*FOOT_WIDTH, -0.5*FOOT_WIDTH]])
 
     
-    def __init__(self, robotStateModel, footstepsPanel, footstepsDriver, playbackPanel, robotStateJointController, ikPlanner, teleopJointController, navigationPanel, cameraView, jointLimitChecker):
+    def __init__(self, robotStateModel, footstepsPanel, footstepsDriver, playbackPanel, robotStateJointController, ikPlanner, teleopJointController, navigationPanel, cameraView):
         self.footstepsPanel = footstepsPanel
         self.footstepsDriver = footstepsDriver
         self.playbackPanel = playbackPanel
@@ -96,7 +96,6 @@ class ContinousWalkingDemo(object):
         self.teleopJointController = teleopJointController
         self.navigationPanel = navigationPanel
         self.cameraView = cameraView
-        self.jointLimitChecker = jointLimitChecker
 
         # live operation flags
         self.leadingFootByUser = 'Left'
@@ -957,9 +956,6 @@ class ContinousWalkingDemo(object):
         lcmUtils.publish('SCS_API_CONTROL', msg)
 
 
-    def autoExtendJointLimits(self):
-        self.jointLimitChecker.automaticallyExtendLimits = True
-
     def executeManipPlan(self):
         self.playbackPanel.executePlan()
 
@@ -1114,7 +1110,6 @@ class ContinuousWalkingTaskPanel(TaskUserPanel):
 
         # prep
         prep = self.taskTree.addGroup('Preparation')
-        addFunc(functools.partial(cw.autoExtendJointLimits), 'auto extend joint limits', parent=prep)
         addTask(rt.SetArmsPosition(name='set arms position'), parent=prep)
         addFunc(functools.partial(cw.executeManipPlan), 'execute arms plan', parent=prep)
         addTask(rt.SetNeckPitch(name='set neck position', angle=50), parent=prep)

--- a/src/python/director/motionplanningpanel.py
+++ b/src/python/director/motionplanningpanel.py
@@ -44,7 +44,8 @@ class WidgetDict(object):
         addWidgetsToDict(widgets, self.__dict__)
         
 class MotionPlanningPanel(object):
-    def __init__(self, robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController, ikPlanner, manipPlanner, affordanceManager, showPlanFunction, hidePlanFunction, footDriver):
+    def __init__(self, planningUtils, robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController, ikPlanner, manipPlanner, affordanceManager, showPlanFunction, hidePlanFunction, footDriver):
+        self.planningUtils = planningUtils
         self.robotStateModel = robotStateModel
         self.robotStateJointController = robotStateJointController
         self.teleopRobotModel = teleopRobotModel
@@ -188,7 +189,7 @@ class MotionPlanningPanel(object):
     
     def updateIKConstraints(self):
         startPoseName = 'reach_start'
-        startPose = np.array(self.robotStateJointController.q)
+        startPose = self.planningUtils.getPlanningStartPose()
         self.ikPlanner.addPose(startPose, startPoseName)
 
         constraints = []
@@ -293,7 +294,7 @@ class MotionPlanningPanel(object):
         self.removeHandFrames()
 
         folder = self.getConstraintFrameFolder()
-        startPose = np.array(self.robotStateJointController.q)        
+        startPose = self.planningUtils.getPlanningStartPose()
         for side in sides:
             linkName = self.ikPlanner.getHandLink(side)
             frameName = '%s constraint frame' % linkName
@@ -347,7 +348,7 @@ class MotionPlanningPanel(object):
         self.robotStateJointController.q[:6] = self.teleopJointController.q[:6]
         self.robotStateJointController.push()
         startPoseName = 'reach_start'
-        startPose = np.array(self.robotStateJointController.q)
+        startPose = self.planningUtils.getPlanningStartPose()
         self.ikPlanner.addPose(startPose, startPoseName)
         self.ui.feetComboBox.setCurrentIndex(1)   
         
@@ -358,7 +359,7 @@ class MotionPlanningPanel(object):
     def onMotionPlan(self):
         self.ui.feetComboBox.setCurrentIndex(1)
         startPoseName = 'reach_start'
-        startPose = np.array(self.robotStateJointController.q)
+        startPose = self.planningUtils.getPlanningStartPose()
         self.checkReachingPlanningMode()
         self.ikPlanner.addPose(startPose, startPoseName)
         plan = self.constraintSet.runIkTraj()
@@ -375,12 +376,12 @@ class MotionPlanningPanel(object):
 def _getAction():
     return app.getToolBarActions()['ActionMotionPlanningPanel']
 
-def init(robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController, debrisPlanner, manipPlanner, affordanceManager, showPlanFunction, hidePlanFunction, footDriver):
+def init(planningUtils, robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController, debrisPlanner, manipPlanner, affordanceManager, showPlanFunction, hidePlanFunction, footDriver):
 
     global panel
     global dock
 
-    panel = MotionPlanningPanel(robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController, debrisPlanner, manipPlanner, affordanceManager, showPlanFunction, hidePlanFunction, footDriver)
+    panel = MotionPlanningPanel(planningUtils, robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController, debrisPlanner, manipPlanner, affordanceManager, showPlanFunction, hidePlanFunction, footDriver)
     dock = app.addWidgetToDock(panel.widget, action=_getAction())
     dock.hide()
 

--- a/src/python/director/plannerPublisher.py
+++ b/src/python/director/plannerPublisher.py
@@ -35,8 +35,6 @@ class PlannerPublisher(object):
             self.jointLimits[jointName][0]=jointPosition
         else:
             self.jointLimits[jointName][1]=jointPosition
-    print limitData
-    print self.jointLimits
 
   def setupMessage(self, constraints, endPoseName="", nominalPoseName="", seedPoseName="", additionalTimeSamples=None):
     poses = ikconstraintencoder.getPlanPoses(constraints, self.ikPlanner)

--- a/src/python/director/planningutils.py
+++ b/src/python/director/planningutils.py
@@ -14,10 +14,13 @@ class PlanningUtils(object):
         self.jointLimitsLower = np.array([self.robotStateModel.model.getJointLimits(jointName)[0] for jointName in robotstate.getDrakePoseJointNames()])
         self.jointLimitsUpper = np.array([self.robotStateModel.model.getJointLimits(jointName)[1] for jointName in robotstate.getDrakePoseJointNames()])
 
-    def getPlanningStartPose(self, clampToJointLimits=True):
+        # Activate/Deactivate joint limit clamper
+        self.clampToJointLimits = False
+
+    def getPlanningStartPose(self):
         startPose = np.array(self.robotStateJointController.q)
 
-        if clampToJointLimits:
+        if self.clampToJointLimits:
             startPose = np.clip(startPose, self.jointLimitsLower, self.jointLimitsUpper)
         
         return startPose

--- a/src/python/director/planningutils.py
+++ b/src/python/director/planningutils.py
@@ -1,0 +1,23 @@
+'''
+PlanningUtils is a centralised helper to provide functions commonly used by 
+motion planners
+'''
+import numpy as np
+from director import robotstate
+
+class PlanningUtils(object):
+    def __init__(self, robotStateModel, robotStateJointController):
+        self.robotStateModel = robotStateModel
+        self.robotStateJointController = robotStateJointController
+
+        # Get joint limits
+        self.jointLimitsLower = np.array([self.robotStateModel.model.getJointLimits(jointName)[0] for jointName in robotstate.getDrakePoseJointNames()])
+        self.jointLimitsUpper = np.array([self.robotStateModel.model.getJointLimits(jointName)[1] for jointName in robotstate.getDrakePoseJointNames()])
+
+    def getPlanningStartPose(self, clampToJointLimits=True):
+        startPose = np.array(self.robotStateJointController.q)
+
+        if clampToJointLimits:
+            startPose = np.clip(startPose, self.jointLimitsLower, self.jointLimitsUpper)
+        
+        return startPose

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -171,10 +171,16 @@ costCollection = PythonQt.dd.ddSignalMap()
 
 if 'fixedBaseArm' in drcargs.getDirectorConfig()['userConfig']:
     ikPlanner.fixedBaseArm = True
+
 if 'disableComponents' in drcargs.getDirectorConfig():
     for component in drcargs.getDirectorConfig()['disableComponents']:
         print "Disabling", component
         locals()[component] = False
+
+if 'enableComponents' in drcargs.getDirectorConfig():
+    for component in drcargs.getDirectorConfig()['enableComponents']:
+        print "Enabling", component
+        locals()[component] = True
 
 
 if useSpreadsheet:

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -68,6 +68,7 @@ from director import handcontrolpanel
 from director import sensordatarequestpanel
 from director import tasklaunchpanel
 from director.jointpropagator import JointPropagator
+from director import planningutils
 
 from director import coursemodel
 
@@ -424,6 +425,7 @@ if usePlanning:
     #app.addToolbarMacro('stereo height', sendFusedHeightRequest)
     #app.addToolbarMacro('stereo depth', sendFusedDepthRequest)
 
+    planningUtils = planningutils.PlanningUtils(robotStateModel, robotStateJointController)
 
     jointLimitChecker = teleoppanel.JointLimitChecker(robotStateModel, robotStateJointController)
     jointLimitChecker.setupMenuAction()
@@ -432,7 +434,7 @@ if usePlanning:
     spindleSpinChecker =  multisensepanel.SpindleSpinChecker(spindleMonitor)
     spindleSpinChecker.setupMenuAction()
 
-    postureShortcuts = teleoppanel.PosturePlanShortcuts(robotStateJointController, ikPlanner)
+    postureShortcuts = teleoppanel.PosturePlanShortcuts(robotStateJointController, ikPlanner, planningUtils)
 
 
     def drillTrackerOn():
@@ -454,9 +456,9 @@ if usePlanning:
     manipPlanner.connectPlanReceived(playbackPanel.setPlan)
 
     teleopPanel = teleoppanel.init(robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController,
-                     ikPlanner, manipPlanner, affordanceManager, playbackPanel.setPlan, playbackPanel.hidePlan)
+                     ikPlanner, manipPlanner, affordanceManager, playbackPanel.setPlan, playbackPanel.hidePlan, planningUtils)
 
-    motionPlanningPanel = motionplanningpanel.init(robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController, 
+    motionPlanningPanel = motionplanningpanel.init(planningUtils, robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController,
                             ikPlanner, manipPlanner, affordanceManager, playbackPanel.setPlan, playbackPanel.hidePlan, footstepsDriver)
     
     if useGamepad:

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -163,6 +163,7 @@ useBlackoutText = True
 useRandomWalk = True
 useCOPMonitor = True
 useCourseModel = False
+useLimitJointsSentToPlanner = True
 notUseOpenniDepthImage = True
 
 poseCollection = PythonQt.dd.ddSignalMap()
@@ -426,6 +427,8 @@ if usePlanning:
     #app.addToolbarMacro('stereo depth', sendFusedDepthRequest)
 
     planningUtils = planningutils.PlanningUtils(robotStateModel, robotStateJointController)
+    if useLimitJointsSentToPlanner:
+        planningUtils.clampToJointLimits = True
 
     jointLimitChecker = teleoppanel.JointLimitChecker(robotStateModel, robotStateJointController)
     jointLimitChecker.setupMenuAction()

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -492,7 +492,7 @@ if usePlanning:
     valveTaskPanel = valvedemo.ValveTaskPanel(valveDemo)
 
     continuouswalkingDemo = continuouswalkingdemo.ContinousWalkingDemo(robotStateModel, footstepsPanel, footstepsDriver, playbackPanel, robotStateJointController, ikPlanner,
-                                                                       teleopJointController, navigationPanel, cameraview, jointLimitChecker)
+                                                                       teleopJointController, navigationPanel, cameraview)
     continuousWalkingTaskPanel = continuouswalkingdemo.ContinuousWalkingTaskPanel(continuouswalkingDemo)
 
     useDrivingPlanner = drivingplanner.DrivingPlanner.isCompatibleWithConfig()

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -163,7 +163,7 @@ useBlackoutText = True
 useRandomWalk = True
 useCOPMonitor = True
 useCourseModel = False
-useLimitJointsSentToPlanner = True
+useLimitJointsSentToPlanner = False
 notUseOpenniDepthImage = True
 
 poseCollection = PythonQt.dd.ddSignalMap()

--- a/src/python/director/teleoppanel.py
+++ b/src/python/director/teleoppanel.py
@@ -816,17 +816,9 @@ class JointLimitChecker(object):
         self.timer.callback = self.update
         self.warningButton = None
         self.action = None
-        self.automaticallyExtendLimits = False
 
     def update(self):
         limitData = self.checkJointLimits()
-
-        # Automatically extend limits (dangerous in practice)
-        if self.automaticallyExtendLimits:
-            if limitData:
-                self.extendJointLimitsAsExceeded(limitData)
-                self.clearStatusBarWarning()
-            return
 
         if limitData:
             self.notifyUserStatusBar(limitData)
@@ -885,15 +877,11 @@ class JointLimitChecker(object):
         msgBox.setText(message)
         msgBox.addButton(QtGui.QPushButton('No'), QtGui.QMessageBox.NoRole)
         msgBox.addButton(QtGui.QPushButton('Yes'), QtGui.QMessageBox.YesRole)
-        msgBox.addButton(QtGui.QPushButton('Yes, then auto'), QtGui.QMessageBox.HelpRole)
         choice = msgBox.exec_()
 
         if choice == 0: # No
             # don't do anything except close the dialog window
             return
-        elif choice == 2: # Yes, then auto
-            self.automaticallyExtendLimits = True
-            self.extendJointLimitsAsExceeded(limitData)
         else:
             self.extendJointLimitsAsExceeded(limitData)
 


### PR DESCRIPTION
Follow up to our lunch discussion with @mauricefallon @yimingyanged @VladimirIvan 
1. Adds ``planningUtils`` in order to assemble methods that are commonly used in motion planning and currently fragmented across multiple files
2. ``planningUtils`` provides a ``getPlanningStartPose()`` method that by default clamps the ``startPose`` of planning problems to the joint limits - thus averting invalid motion plans (that e.g. trip up IHMC's controller)
3. Replaced all uses of manually getting the poses in the teleop and motion planning panels with the new ``getPlanningStartPose`` method

@mauricefallon @yimingyanged would you please have a look over this?

cc: @MarcoCar FYI

**ToDo:**

- [ ] Use ``planningUtils`` across all demos
- [x] remove print output in PlannerPublisher.updateJointLimits()
- [ ] deprecate extending joint limits/leave them untouched for both Matlab as well as EXOTica planners
- [x] make decision flag a property of the class, so that it can be changed globally
- [x] have this property set by a high level variable from startup.py (and in turn from director_config.json)
  - this would mean extending the field 'disableComponents' which can switch off components. There should be both a disableComponents list and an enableComponents list