### PR TITLE
Fix unit tests

### DIFF
--- a/src/python/tests/testContinuousWalking.py
+++ b/src/python/tests/testContinuousWalking.py
@@ -71,7 +71,7 @@ def processSnippet():
 #navigationPanel = navigationpanel.init(robotStateJointController, footstepsDriver)
 navigationPanel = None
 continuouswalkingDemo = continuouswalkingdemo.ContinousWalkingDemo(robotStateModel, footstepsPanel, footstepsDriver, playbackpanel, robotStateJointController, ikPlanner,
-                                                                       teleopJointController, navigationPanel, cameraview, jointLimitChecker=None)
+                                                                       teleopJointController, navigationPanel, cameraview)
 
 cwdemo = continuouswalkingDemo
 

--- a/src/python/tests/testContinuousWalking_staircase.py
+++ b/src/python/tests/testContinuousWalking_staircase.py
@@ -34,7 +34,7 @@ def processSingleBlock(robotStateModel, whichFile=0):
         polyData = ioUtils.readPolyData(os.path.join(dataDir, 'terrain/terrain_simple_ihmc.vtp'))
         vis.updatePolyData( polyData, 'terrain_simple_ihmc.vtp', parent='continuous')
     else:
-        polyData = ioUtils.readPolyData(os.path.join(dataDir, 'terrain/terrain_stairs_ihmc.vtp'))
+        polyData = ioUtils.readPolyData(os.path.join(dataDir, 'terrain/terrain_flagstones_ihmc.vtp'))
         cwdemo.chosenTerrain = 'stairs'
         cwdemo.supportContact = lcmdrc.footstep_params_t.SUPPORT_GROUPS_MIDFOOT_TOE
         vis.updatePolyData( polyData, 'terrain_stairs_ihmc.vtp', parent='continuous')
@@ -103,7 +103,7 @@ def processSnippet():
 #navigationPanel = navigationpanel.init(robotStateJointController, footstepsDriver)
 navigationPanel = None
 continuouswalkingDemo = continuouswalkingdemo.ContinousWalkingDemo(robotStateModel, footstepsPanel, footstepsDriver, playbackpanel, robotStateJointController, ikPlanner,
-                                                                       teleopJointController, navigationPanel, cameraview, jointLimitChecker=None)
+                                                                       teleopJointController, navigationPanel, cameraview)
 
 cwdemo = continuouswalkingDemo
 

--- a/src/python/tests/testTeleopPanel.py
+++ b/src/python/tests/testTeleopPanel.py
@@ -5,6 +5,7 @@ from director import visualization as vis
 from director import objectmodel as om
 from director import teleoppanel
 from director import playbackpanel
+from director import planningutils
 
 from PythonQt import QtCore, QtGui
 import numpy as np
@@ -61,8 +62,9 @@ robotsystem.create(view, globals())
 playbackPanel = playbackpanel.PlaybackPanel(planPlayback, playbackRobotModel, playbackJointController,
                                   robotStateModel, robotStateJointController, manipPlanner)
 
+planningUtils = planningutils.PlanningUtils(robotStateModel, robotStateJointController)
 teleopPanel = teleoppanel.TeleopPanel(robotStateModel, robotStateJointController, teleopRobotModel, teleopJointController,
-                 ikPlanner, manipPlanner, affordanceManager, playbackPanel.setPlan, playbackPanel.hidePlan)
+                 ikPlanner, manipPlanner, affordanceManager, playbackPanel.setPlan, playbackPanel.hidePlan, planningUtils)
 
 manipPlanner.connectPlanReceived(playbackPanel.setPlan)
 


### PR DESCRIPTION
Now that a build server is back up, it became clear that https://github.com/RobotLocomotion/director/pull/295 broke some of our unit tests, cf. [build server failures](http://kobol.csail.mit.edu/cd/viewTest.php?onlyfailed&buildid=23686).

This PR fixes some of them. Additionally, the catkin workspace is now being built on the server a well which should take care of a further few.