### PR TITLE
Updated from-source-vtk5 to point to an updated clone that defines GLX_GLXEXT_LEGACY.

### DIFF
--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -193,8 +193,8 @@ option(USE_SYSTEM_VTK "Use system version of VTK.  If off, VTK will be built." $
 
 if(NOT USE_SYSTEM_VTK)
   ExternalProject_Add(vtk
-    GIT_REPOSITORY https://github.com/bilke/VTK.git
-    GIT_TAG b753b7f # vtk 5.10 with fixes for Visual Studio 2013
+    GIT_REPOSITORY https://github.com/liangfok/VTK.git
+    GIT_TAG ec43254f432af2e49f10bd2d1996cc578895c19f # vtk 5.10 with fixes for Visual Studio 2013 and GLX_GLXEXT_LEGACY.
     CMAKE_CACHE_ARGS
       ${default_cmake_args}
       ${python_args}


### PR DESCRIPTION
For reference: https://github.com/RobotLocomotion/drake/issues/3703#issuecomment-252459041