### PR TITLE
support point clouds in the drake visualizer interface

### DIFF
--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -296,6 +296,7 @@ class DrakeVisualizer(object):
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_LOAD_ROBOT', lcmdrake.lcmt_viewer_load_robot, self.onViewerLoadRobot))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_DRAW', lcmdrake.lcmt_viewer_draw, self.onViewerDraw))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_PLANAR_LIDAR_.*', lcmbot.planar_lidar_t, self.onPlanarLidar, callbackNeedsChannel=True))
+        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_POINTCLOUD_.*', lcmbot.pointcloud_t, self.onPointCloud, callbackNeedsChannel=True))
 
     def _removeSubscribers(self):
         for sub in self.subscribers:
@@ -333,6 +334,10 @@ class DrakeVisualizer(object):
 
     def getLinkFolder(self, robotNum, linkName):
         return om.getOrCreateContainer(linkName, parentObj=self.getRobotFolder(robotNum))
+
+    def getPointcloudFolder(self, pointcloudName):
+        parent = om.getOrCreateContainer('pointclouds', parentObj=self.getRootFolder())
+        return om.getOrCreateContainer(pointcloudName, parentObj=parent)
 
     def addLink(self, link, robotNum, linkName):
         self.robots.setdefault(robotNum, {})[linkName] = link
@@ -434,6 +439,39 @@ class DrakeVisualizer(object):
             polyData.SetVerts(verts)
 
 
+    def onPointCloud(self, msg, channel):
+        pointcloudName = channel.replace('DRAKE_POINTCLOUD_', '', 1)
+
+        polyData = vnp.numpyToPolyData(np.asarray(msg.points), createVertexCells=True)
+
+        # If the user provided color channels, then use them to colorize
+        # the pointcloud.
+        channels = {msg.channel_names[i]: msg.channels[i] for i in range(msg.n_channels)}
+        if "r" in channels and "g" in channels and "b" in channels:
+            rgb = vtk.vtkUnsignedCharArray()
+            rgb.SetName("rgb")
+            rgb.SetNumberOfComponents(3)
+            rgb.SetNumberOfTuples(msg.n_points)
+            polyData.GetPointData().AddArray(rgb)
+            for (color_index, color) in enumerate(["r", "g", "b"]):
+                channel = channels[color]
+                for i in range(msg.n_points):
+                    rgb.SetComponent(i, color_index, 255 * channel[i])
+
+        folder = self.getPointcloudFolder(pointcloudName)
+        # If there was an existing point cloud by this name, then just
+        # set its polyData to the new point cloud.
+        # This has the effect of preserving all the user-specified properties
+        # like point size, coloration mode, alpha, etc.
+        if len(folder.children()):
+            previous_pointcloud = folder.children()[0]
+            previous_pointcloud.setPolyData(polyData)
+            previous_pointcloud._updateColorByProperty()
+        else:
+            item = vis.PolyDataItem("pointcloud", polyData, view=None)
+            item.addToView(self.view)
+            item._updateColorByProperty()
+            om.addToObjectModel(item, parentObj=self.getPointcloudFolder(pointcloudName))
 
 
 ##########################################################

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -448,6 +448,7 @@ class DrakeVisualizer(object):
         # the pointcloud.
         channels = {msg.channel_names[i]: msg.channels[i] for i in range(msg.n_channels)}
         if "r" in channels and "g" in channels and "b" in channels:
+            colorized = True
             rgb = vtk.vtkUnsignedCharArray()
             rgb.SetName("rgb")
             rgb.SetNumberOfComponents(3)
@@ -457,6 +458,8 @@ class DrakeVisualizer(object):
                 channel = channels[color]
                 for i in range(msg.n_points):
                     rgb.SetComponent(i, color_index, 255 * channel[i])
+        else:
+            colorized = False
 
         folder = self.getPointcloudFolder(pointcloudName)
         # If there was an existing point cloud by this name, then just
@@ -470,7 +473,9 @@ class DrakeVisualizer(object):
         else:
             item = vis.PolyDataItem("pointcloud", polyData, view=None)
             item.addToView(self.view)
-            item._updateColorByProperty()
+            if colorized:
+                item._updateColorByProperty()
+                item.setProperty("Color By", "rgb")
             om.addToObjectModel(item, parentObj=self.getPointcloudFolder(pointcloudName))
 
 


### PR DESCRIPTION
fixes #317 

This implements an initial draft of point cloud support in the `drake-visualizer` interface. I expect that it may need to evolve a bit to support all of our use cases, but I think this is a good start. 

The interface I'm proposing is as follows:

To draw a point cloud, the user sends a message of type `bot_core::pointcloud_t` on the channel `DRAKE_POINTCLOUD_<pointcloud name>`, where `<pointcloud name>` is some unique name to identify this particular point cloud. The format of the message is:

* `n_points`: number of points in the pointcloud
* `points`: `n_points` x 3 array of points in world x, y, z coordinates
* `n_channels`: number of additional data channels (such as desired color, see below)
* `channel_names`: `n_channels` array of strings naming particular data channels.
  * the only channels supported currently are named `"r"`, `"g"`, and `"b"`, see below
* `channels`: `n_channels` x `n_points` array of additional data. 
  * supported channels are r, g, and b, which set the RGB color of each point. Each RGB value should be in the range [0, 1] (note that Director internally uses 0-255 for colors, but I think 0-1 is more appropriate for a floating point value. I'm open to changing this.)

all other fields in the message are ignored. 

If a previous point cloud has been published with the same name, then it will be replaced by the new point cloud. However, user-selected properties like point size and alpha will carry over into the new point cloud. 

Does this cover our desired use cases? 

cc @gizatt @RussTedrake 