### PR TITLE
don't clear pointclouds on load_robot

### DIFF
--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -362,7 +362,8 @@ class DrakeVisualizer(object):
 
     def removeAllRobots(self):
         for child in self.getRootFolder().children():
-            om.removeFromObjectModel(child)
+            if child.getProperty('Name') != "pointclouds":
+                om.removeFromObjectModel(child)
         self.robots = {}
 
     def sendStatusMessage(self, message):


### PR DESCRIPTION
Currently, a DRAKE_VIEWER_LOAD_ROBOT message deletes the entire drake visualizer folder in the Director object model, which also deletes all point clouds currently being displayed. This change prevents point clouds from being deleted. 

Alternatively, instead of accepting this change, we can decide that the current behavior is actually correct. I'm open to discussion. Should drawing a new robot clear the pointclouds? 