### PR TITLE
adds relative height filtering for lidar

### DIFF
--- a/src/python/director/perception.py
+++ b/src/python/director/perception.py
@@ -48,6 +48,10 @@ class MultisenseItem(om.ObjectModelItem):
                          attributes=om.PropertyAttributes(decimals=0, minimum=1, maximum=20, singleStep=1, hidden=False))
         self.addProperty('Alpha', model.alpha,
                          attributes=om.PropertyAttributes(decimals=2, minimum=0, maximum=1.0, singleStep=0.1, hidden=False))
+        self.addProperty('Min Height', model.reader.GetHeightRange()[0],
+                         attributes=om.PropertyAttributes(decimals=2, minimum=-80.0, maximum=80.0, singleStep=0.25, hidden=False))
+        self.addProperty('Max Height', model.reader.GetHeightRange()[1],
+                         attributes=om.PropertyAttributes(decimals=2, minimum=-80.0, maximum=80.0, singleStep=0.25, hidden=False))
 
         #self.addProperty('Color', QtGui.QColor(255,255,255))
         #self.addProperty('Scanline Color', QtGui.QColor(255,0,0))
@@ -80,6 +84,10 @@ class MultisenseItem(om.ObjectModelItem):
 
         elif propertyName in ('Min Range', 'Max Range'):
             self.model.reader.SetDistanceRange(self.getProperty('Min Range'), self.getProperty('Max Range'))
+            self.model.showRevolution(self.model.displayedRevolution)
+
+        elif propertyName in ('Min Height', 'Max Height'):
+            self.model.reader.SetHeightRange(self.getProperty('Min Height'), self.getProperty('Max Height'))
             self.model.showRevolution(self.model.displayedRevolution)
 
         elif propertyName == 'Color By':
@@ -145,6 +153,10 @@ class LidarItem(om.ObjectModelItem):
                          attributes=om.PropertyAttributes(decimals=0, minimum=-1, maximum=20, singleStep=1, hidden=False))
         self.addProperty('Alpha', model.alpha,
                          attributes=om.PropertyAttributes(decimals=2, minimum=0, maximum=1.0, singleStep=0.1, hidden=False))
+        self.addProperty('Min Height', model.reader.GetHeightRange()[0],
+                         attributes=om.PropertyAttributes(decimals=2, minimum=-80.0, maximum=80.0, singleStep=0.25, hidden=False))
+        self.addProperty('Max Height', model.reader.GetHeightRange()[1],
+                         attributes=om.PropertyAttributes(decimals=2, minimum=-80.0, maximum=80.0, singleStep=0.25, hidden=False))
 
         #self.addProperty('Color', QtGui.QColor(255,255,255))
         #self.addProperty('Scanline Color', QtGui.QColor(255,0,0))
@@ -177,6 +189,10 @@ class LidarItem(om.ObjectModelItem):
 
         elif propertyName in ('Min Range', 'Max Range'):
             self.model.reader.SetDistanceRange(self.getProperty('Min Range'), self.getProperty('Max Range'))
+            #    self.model.showRevolution(self.model.displayedRevolution)
+
+        elif propertyName in ('Min Height', 'Max Height'):
+            self.model.reader.SetHeightRange(self.getProperty('Min Height'), self.getProperty('Max Height'))
             #    self.model.showRevolution(self.model.displayedRevolution)
 
         elif propertyName == 'Color By':
@@ -339,6 +355,7 @@ class MultiSenseSource(TimerCallback):
             self.reader = drc.vtkMultisenseSource()
             self.reader.InitBotConfig(drcargs.args().config_file)
             self.reader.SetDistanceRange(0.25, 4.0)
+            self.reader.SetHeightRange(-80.0, 80.0)
             self.reader.Start()
 
         TimerCallback.start(self)
@@ -537,6 +554,7 @@ class LidarSource(TimerCallback):
             self.reader = drc.vtkLidarSource()
             self.reader.InitBotConfig(drcargs.args().config_file)
             self.reader.SetDistanceRange(0.25, 80.0)
+            self.reader.SetHeightRange(-80.0, 80.0)
             self.reader.Start()
 
         TimerCallback.start(self)
@@ -720,6 +738,10 @@ class MapServerSource(TimerCallback):
                              attributes=om.PropertyAttributes(decimals=2, minimum=0.0, maximum=100.0, singleStep=0.25, hidden=False))
             folder.addProperty('Edge Filter Angle', self.reader.GetEdgeAngleThreshold(),
                          attributes=om.PropertyAttributes(decimals=0, minimum=0.0, maximum=60.0, singleStep=1, hidden=False))
+            folder.addProperty('Min Height', self.reader.GetHeightRange()[0],
+                             attributes=om.PropertyAttributes(decimals=2, minimum=-80.0, maximum=80.0, singleStep=0.25, hidden=False))
+            folder.addProperty('Max Height', self.reader.GetHeightRange()[1],
+                             attributes=om.PropertyAttributes(decimals=2, minimum=-80.0, maximum=80.0, singleStep=0.25, hidden=False))
             om.addToObjectModel(obj, folder)
             om.expand(folder)
             self.folder = folder
@@ -775,6 +797,7 @@ class MapServerSource(TimerCallback):
         if (self.folder):
             self.reader.SetDistanceRange(self.folder.getProperty('Min Range'), self.folder.getProperty('Max Range'))
             self.reader.SetEdgeAngleThreshold(self.folder.getProperty('Edge Filter Angle'))
+            self.reader.SetHeightRange(self.folder.getProperty('Min Height'), self.folder.getProperty('Max Height'))
             
         viewIds = self.reader.GetViewIds()
         viewIds = vnp.numpy_support.vtk_to_numpy(viewIds) if viewIds.GetNumberOfTuples() else []

--- a/src/vtk/DRCFilters/vtkLidarSource.h
+++ b/src/vtk/DRCFilters/vtkLidarSource.h
@@ -42,6 +42,9 @@ public:
   vtkGetVector2Macro(DistanceRange, double);
   vtkSetVector2Macro(DistanceRange, double);
 
+  vtkGetVector2Macro(HeightRange, double);
+  vtkSetVector2Macro(HeightRange, double);
+
   void SetEdgeAngleThreshold(double threshold);
   double GetEdgeAngleThreshold();
 
@@ -77,6 +80,7 @@ protected:
 
   double DistanceRange[2];
   double EdgeAngleThreshold;
+  double HeightRange[2];
 
 private:
   vtkLidarSource(const vtkLidarSource&);  // Not implemented.

--- a/src/vtk/DRCFilters/vtkMapServerSource.cxx
+++ b/src/vtk/DRCFilters/vtkMapServerSource.cxx
@@ -237,6 +237,8 @@ public:
     this->DistanceRange[0] = 0.25;
     this->DistanceRange[1] = 4.0;
     this->EdgeAngleThreshold = 30;  // degrees
+    this->HeightRange[0] = -80.0;
+    this->HeightRange[1] =  80.0;
 
     this->LCMHandle = std::shared_ptr<lcm::LCM>(new lcm::LCM);
     if(!this->LCMHandle->good())
@@ -277,6 +279,12 @@ public:
     this->DistanceRange[0] = distanceRange[0];
     this->DistanceRange[1] = distanceRange[1];
   }
+
+  void SetHeightRange(double heightRange[2])
+  {
+    this->HeightRange[0] = heightRange[0];
+    this->HeightRange[1] = heightRange[1];
+  }  
 
   void SetEdgeAngleThreshold(double edgeAngleThreshold)
   {
@@ -693,7 +701,7 @@ protected:
     }
 
     MapData mapData;
-    mapData.Data = GetPointCloudFromScanLines(scanLines, this->DistanceRange, this->EdgeAngleThreshold);
+    mapData.Data = GetPointCloudFromScanLines(scanLines, this->DistanceRange, this->EdgeAngleThreshold, this->HeightRange);
     mapData.Transform = this->ToVtkTransform(bundleView.getTransform());
     mapData.Mesh = mapData.Data;
 
@@ -714,6 +722,7 @@ protected:
 
   double EdgeAngleThreshold;
   double DistanceRange[2];
+  double HeightRange[2];
 
   std::mutex Mutex;
   int64_t LastScanBundleUtime;
@@ -760,6 +769,9 @@ vtkMapServerSource::vtkMapServerSource()
   this->DistanceRange[0] = 0.25;
   this->DistanceRange[1] = 4.0;
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->HeightRange[0] = -80.0;
+  this->HeightRange[1] =  80.0;
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
 }
 
 //----------------------------------------------------------------------------
@@ -812,6 +824,7 @@ double vtkMapServerSource::GetEdgeAngleThreshold()
 int vtkMapServerSource::GetNumberOfDatasets(int viewId)
 {
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
   return this->Internal->Listener->GetDatasets(viewId).size();
 }
 
@@ -819,6 +832,7 @@ int vtkMapServerSource::GetNumberOfDatasets(int viewId)
 vtkIdType vtkMapServerSource::GetCurrentMapId(int viewId)
 {
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
   return this->Internal->Listener->GetCurrentMapId(viewId);
 }
 
@@ -826,6 +840,7 @@ vtkIdType vtkMapServerSource::GetCurrentMapId(int viewId)
 void vtkMapServerSource::GetDataForMapId(int viewId, vtkIdType mapId, vtkPolyData* polyData)
 {
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
   this->Internal->Listener->GetDataForMapId(viewId, mapId, polyData);
 }
 
@@ -833,6 +848,7 @@ void vtkMapServerSource::GetDataForMapId(int viewId, vtkIdType mapId, vtkPolyDat
 void vtkMapServerSource::GetMeshForMapId(int viewId, vtkIdType mapId, vtkPolyData* polyData)
 {
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
   this->Internal->Listener->GetMeshForMapId(viewId, mapId, polyData);
 }
 
@@ -840,6 +856,7 @@ void vtkMapServerSource::GetMeshForMapId(int viewId, vtkIdType mapId, vtkPolyDat
 void vtkMapServerSource::GetDataForMapId(int viewId, vtkIdType mapId, vtkImageData* imageData, vtkTransform* transform)
 {
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
   this->Internal->Listener->GetDataForMapId(viewId, mapId, imageData, transform);
 }
 
@@ -852,6 +869,7 @@ vtkIdType vtkMapServerSource::GetLastScanBundleUTime()
 vtkPolyData* vtkMapServerSource::GetDataset(int viewId, vtkIdType i)
 {
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
   return this->Internal->Listener->GetDatasetForTime(viewId, i);
 }
 
@@ -859,6 +877,7 @@ vtkPolyData* vtkMapServerSource::GetDataset(int viewId, vtkIdType i)
 vtkIntArray* vtkMapServerSource::GetViewIds()
 {
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
   return this->Internal->Listener->GetViewIds();
 }
 
@@ -907,6 +926,7 @@ int vtkMapServerSource::RequestData(
     }
 
   this->Internal->Listener->SetDistanceRange(this->DistanceRange);
+  this->Internal->Listener->SetHeightRange(this->HeightRange);
   vtkSmartPointer<vtkPolyData> polyData = this->Internal->Listener->GetDatasetForTime(WORKSPACE_DEPTH_VIEW_ID, timestep);
   if (polyData)
     {

--- a/src/vtk/DRCFilters/vtkMapServerSource.h
+++ b/src/vtk/DRCFilters/vtkMapServerSource.h
@@ -43,6 +43,9 @@ public:
   vtkGetVector2Macro(DistanceRange, double);
   vtkSetVector2Macro(DistanceRange, double);
 
+  vtkGetVector2Macro(HeightRange, double);
+  vtkSetVector2Macro(HeightRange, double);
+
   void SetEdgeAngleThreshold(double threshold);
   double GetEdgeAngleThreshold();
 
@@ -74,6 +77,7 @@ protected:
 
   double DistanceRange[2];
   double EdgeAngleThreshold;
+  double HeightRange[2];
 
 private:
   vtkMapServerSource(const vtkMapServerSource&);  // Not implemented.

--- a/src/vtk/DRCFilters/vtkMultisenseSource.h
+++ b/src/vtk/DRCFilters/vtkMultisenseSource.h
@@ -42,6 +42,9 @@ public:
   vtkGetVector2Macro(DistanceRange, double);
   vtkSetVector2Macro(DistanceRange, double);
 
+  vtkGetVector2Macro(HeightRange, double);
+  vtkSetVector2Macro(HeightRange, double);
+
   void SetEdgeAngleThreshold(double threshold);
   double GetEdgeAngleThreshold();
 
@@ -74,6 +77,7 @@ protected:
   virtual ~vtkMultisenseSource();
 
   double DistanceRange[2];
+  double HeightRange[2];
   double EdgeAngleThreshold;
 
 private:


### PR DESCRIPTION
for example you can choose to only show lidar 1m below and 2m above the body frame. especially useful for mobile robots where trees and ceilings are a pain as you are usually only interested in the above

demo shows the previous case (with the trees in the way) and then the control dials were added to show only the lidar around the robot's height:
https://www.dropbox.com/s/vghhtrwi7iojuzo/2016-10-lidar_height_control.mp4?dl=0

To be honest I was surprised at the sheer number of changes needed to add this feature