### PR TITLE
Added logic to fail fast if user wants to use system VTK but version 5 is not available.

### DIFF
--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -256,6 +256,11 @@ if(NOT USE_SYSTEM_VTK)
   set(vtk_args -DVTK_DIR:PATH=${install_prefix}/lib/vtk-5.10)
   set(vtk_depends vtk)
 else()
+  # Verifies that the system has VTK5.
+  find_package(VTK REQUIRED)
+  if (NOT ${VTK_VERSION_MAJOR} EQUAL 5)
+    message(FATAL_ERROR "System does not have VTK5. It has version ${VTK_VERSION}.")
+  endif()
 
   set(vtk_homebrew_dir /usr/local/opt/vtk5/lib/vtk-5.10)
   if (APPLE AND IS_DIRECTORY ${vtk_homebrew_dir})

--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -256,17 +256,16 @@ if(NOT USE_SYSTEM_VTK)
   set(vtk_args -DVTK_DIR:PATH=${install_prefix}/lib/vtk-5.10)
   set(vtk_depends vtk)
 else()
-  # Verifies that the system has VTK5.
-  find_package(VTK REQUIRED)
-  if (NOT ${VTK_VERSION_MAJOR} EQUAL 5)
-    message(FATAL_ERROR "System does not have VTK5. It has version ${VTK_VERSION}.")
-  endif()
-
   set(vtk_homebrew_dir /usr/local/opt/vtk5/lib/vtk-5.10)
   if (APPLE AND IS_DIRECTORY ${vtk_homebrew_dir})
     set(vtk_args -DVTK_DIR:PATH=${vtk_homebrew_dir})
   endif()
 
+  # Verifies that the system has VTK5.
+  find_package(VTK REQUIRED HINTS ${vtk_homebrew_dir})
+  if (NOT ${VTK_VERSION_MAJOR} EQUAL 5)
+    message(FATAL_ERROR "System does not have VTK5. It has version ${VTK_VERSION}.")
+  endif()
 endif()
 
 


### PR DESCRIPTION
I tested on this on Ubuntu 16.04 with ROS Kinetic (which has VTK6) and it worked -- the error was printed during the configure stage. I also tested it on Ubuntu 14.04 with ROS Indigo and Director was able to compile using the system VTK.

Resolves #311.