### PR TITLE
Check whether transform exists in ddBotImageQueue and return if it do…

### DIFF
--- a/src/app/ddBotImageQueue.cpp
+++ b/src/app/ddBotImageQueue.cpp
@@ -742,6 +742,10 @@ QList<double> ddBotImageQueue::unprojectPixel(const QString& cameraName, int px,
 //-----------------------------------------------------------------------------
 QList<double> ddBotImageQueue::getCameraFrustumBounds(CameraData* cameraData)
 {
+  // Check whether transform exists and return to avoid segfault
+  if (!cameraData->mCamTrans)
+    return QList<double>();
+
   double width = bot_camtrans_get_image_width(cameraData->mCamTrans);
   double height = bot_camtrans_get_image_width(cameraData->mCamTrans);
   double ray[4][3];


### PR DESCRIPTION
…esnt to avoid segfault

Thanks to this we don't need to define pseudo CAMERA_LEFT frames etc. in robot.cfg files for robots that don't have a multisense