### PR TITLE
Finish pydrake ik server

### DIFF
--- a/src/python/director/teleoppanel.py
+++ b/src/python/director/teleoppanel.py
@@ -1225,7 +1225,7 @@ class JointTeleopPanel(object):
 
     def computeBaseJointOffsets(self):
 
-        if self.panel.ikPlanner.robotNoFeet:
+        if True or self.panel.ikPlanner.robotNoFeet:
             baseReferenceFrame = vtk.vtkTransform()
         else:
             from director import footstepsdriver


### PR DESCRIPTION
Todos:
- [ ] backport InverseKinTraj/Pointwise wrappers to oh fork of drake

These functions are callable in the pydrake interface of drake/master, but are currently missing from the oh fork of drake
- [x] add support for receiving plan messages as robot_plan_t

Normally the message published on CANDIDATE_MANIP_PLAN is a keyframe plan message type.  The keyframe message type is only in drc lcmtypes.  I could copy it to robotlocomotion/lcmtypes, or just add support in director to receive either message type on the channel.
- [ ] move the code for accessing foot contact points and foot stance frames

Currently this code lives in FootstepsDriver.  But this code is useful for general planning and shouldn't add a dependency on the footsteps driver.  For example, the Teleop panel depends on FootstepsDriver, I want to remove that dependency.
- [x] publish plan messages from the PyDrakeIkServer

I will implement some basic code in the PyDrakeIkServer to convert a q_sol output of InverseKinTraj to a robot_plan_t.  But we have a lot of existing functionality in Matlab's RobotPlanPublisher, and I do not plan to re-implement that much in Python.  Instead, the conversion should be implemented in drake c++ libs (perhaps with the help of @sammy-tri) and then I can call it from Python.
- [x] add an example director_config.json file for the kuka urdf model in drake/examples
- [x] add support for FixedLinkFromRobotPoseConstraint in the PyDrakeIkServer

I also need to find out from @avalenzu why we have this constraint, and why I shouldn't roll back to using the six dof constraints.
