### PR TITLE
Use RigidBodyTreed typedef 

### DIFF
--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -424,7 +424,7 @@ ddMeshVisual::Ptr makeBoxVisual(double x, double y, double z)
   return visualFromPolyData(shallowCopy(cube->GetOutput()));
 }
 
-class URDFRigidBodyTreeVTK : public RigidBodyTree
+class URDFRigidBodyTreeVTK : public RigidBodyTreed
 {
 public:
 
@@ -447,7 +447,7 @@ public:
   {
     this->dofMap.clear();
 
-    RigidBodyTree* model = this;
+    RigidBodyTreed* model = this;
 
     const RigidBody& worldBody = model->world();
     for (const RigidBody* body : model->FindModelInstanceBodies(
@@ -588,7 +588,7 @@ public:
   void loadVisuals(const QString& rootDir=".")
   {
 
-    RigidBodyTree* model = this;
+    RigidBodyTreed* model = this;
 
     for (const RigidBody* body : model->FindModelInstanceBodies(
              model->world().get_model_instance_id())) {
@@ -668,7 +668,7 @@ public:
 
   virtual void updateModel()
   {
-    RigidBodyTree* model = this;
+    RigidBodyTreed* model = this;
 
     for (const RigidBody* body : model->FindModelInstanceBodies(
              model->world().get_model_instance_id())) {
@@ -699,7 +699,7 @@ public:
     QMap<QString, int> linkMap;
 
 
-    RigidBodyTree* model = this;
+    RigidBodyTreed* model = this;
 
     for (const RigidBody* body : model->FindModelInstanceBodies(
              model->world().get_model_instance_id())) {
@@ -796,7 +796,7 @@ ddDrakeModel::~ddDrakeModel()
 }
 
 //-----------------------------------------------------------------------------
-const ddSharedPtr<RigidBodyTree> ddDrakeModel::getDrakeRBM() const
+const ddSharedPtr<RigidBodyTreed> ddDrakeModel::getDrakeRBM() const
 {
   return this->Internal->Model;
 }

--- a/src/app/ddDrakeModel.h
+++ b/src/app/ddDrakeModel.h
@@ -11,7 +11,7 @@
 class vtkRenderer;
 class vtkTransform;
 class vtkPolyData;
-class RigidBodyTree;
+class RigidBodyTreed;
 
 class DD_APP_EXPORT ddDrakeModel : public QObject
 {
@@ -26,7 +26,7 @@ public:
   bool loadFromXML(const QString& xmlString);
   const QString& filename() const;
 
-  const ddSharedPtr<RigidBodyTree> getDrakeRBM() const;
+  const ddSharedPtr<RigidBodyTreed> getDrakeRBM() const;
   const ddSharedPtr<KinematicsCache<double> > getKinematicsCache() const;
 
   void addToRenderer(vtkRenderer* renderer);

--- a/src/app/ddDrakeModel.h
+++ b/src/app/ddDrakeModel.h
@@ -11,7 +11,6 @@
 class vtkRenderer;
 class vtkTransform;
 class vtkPolyData;
-class RigidBodyTreed;
 
 class DD_APP_EXPORT ddDrakeModel : public QObject
 {

--- a/src/app/ddDrakeModelOH.cpp
+++ b/src/app/ddDrakeModelOH.cpp
@@ -425,7 +425,7 @@ ddMeshVisual::Ptr makeBoxVisual(double x, double y, double z)
   return visualFromPolyData(shallowCopy(cube->GetOutput()));
 }
 
-class URDFRigidBodyTreeVTK : public RigidBodyTree
+class URDFRigidBodyTreeVTK : public RigidBodyTreed
 {
 public:
 
@@ -448,7 +448,7 @@ public:
   {
     this->dofMap.clear();
 
-    RigidBodyTree* model = this;
+    RigidBodyTreed* model = this;
 
     const std::shared_ptr<RigidBody> worldBody = model->bodies[0];
 
@@ -593,7 +593,7 @@ public:
   void loadVisuals(const QString& rootDir=".")
   {
 
-    RigidBodyTree* model = this;
+    RigidBodyTreed* model = this;
 
     for (size_t bodyIndex = 0; bodyIndex < model->bodies.size(); ++bodyIndex)
     {
@@ -674,7 +674,7 @@ public:
 
   virtual void updateModel()
   {
-    RigidBodyTree* model = this;
+    RigidBodyTreed* model = this;
 
     for (size_t bodyIndex = 0; bodyIndex < model->bodies.size(); ++bodyIndex)
     {
@@ -708,7 +708,7 @@ public:
     QMap<QString, int> linkMap;
 
 
-    RigidBodyTree* model = this;
+    RigidBodyTreed* model = this;
 
     for (size_t bodyIndex = 0; bodyIndex < model->bodies.size(); ++bodyIndex)
     {
@@ -807,7 +807,7 @@ ddDrakeModel::~ddDrakeModel()
 }
 
 //-----------------------------------------------------------------------------
-const ddSharedPtr<RigidBodyTree> ddDrakeModel::getDrakeRBM() const
+const ddSharedPtr<RigidBodyTreed> ddDrakeModel::getDrakeRBM() const
 {
   return this->Internal->Model;
 }

--- a/src/app/ddDrakeModelOH.cpp
+++ b/src/app/ddDrakeModelOH.cpp
@@ -425,7 +425,7 @@ ddMeshVisual::Ptr makeBoxVisual(double x, double y, double z)
   return visualFromPolyData(shallowCopy(cube->GetOutput()));
 }
 
-class URDFRigidBodyTreeVTK : public RigidBodyTreed
+class URDFRigidBodyTreeVTK : public RigidBodyTree
 {
 public:
 
@@ -448,7 +448,7 @@ public:
   {
     this->dofMap.clear();
 
-    RigidBodyTreed* model = this;
+    RigidBodyTree* model = this;
 
     const std::shared_ptr<RigidBody> worldBody = model->bodies[0];
 
@@ -593,7 +593,7 @@ public:
   void loadVisuals(const QString& rootDir=".")
   {
 
-    RigidBodyTreed* model = this;
+    RigidBodyTree* model = this;
 
     for (size_t bodyIndex = 0; bodyIndex < model->bodies.size(); ++bodyIndex)
     {
@@ -674,7 +674,7 @@ public:
 
   virtual void updateModel()
   {
-    RigidBodyTreed* model = this;
+    RigidBodyTree* model = this;
 
     for (size_t bodyIndex = 0; bodyIndex < model->bodies.size(); ++bodyIndex)
     {
@@ -708,7 +708,7 @@ public:
     QMap<QString, int> linkMap;
 
 
-    RigidBodyTreed* model = this;
+    RigidBodyTree* model = this;
 
     for (size_t bodyIndex = 0; bodyIndex < model->bodies.size(); ++bodyIndex)
     {
@@ -807,7 +807,7 @@ ddDrakeModel::~ddDrakeModel()
 }
 
 //-----------------------------------------------------------------------------
-const ddSharedPtr<RigidBodyTreed> ddDrakeModel::getDrakeRBM() const
+const ddSharedPtr<RigidBodyTree> ddDrakeModel::getDrakeRBM() const
 {
   return this->Internal->Model;
 }

--- a/src/app/ddDrakeWrapper.cpp
+++ b/src/app/ddDrakeWrapper.cpp
@@ -32,7 +32,7 @@ QVector<double> ddDrakeWrapper::resolveCenterOfPressure(const ddDrakeModel& ddMo
 {
   // Assumes size of ft_in = size of ft_frame_inds*6, in order (one wrench at a time)
   // returns a 4-vector, which is packed output of RBM resolveCOP, with vector first
-  ddSharedPtr<RigidBodyTree> model = ddModel.getDrakeRBM();
+  ddSharedPtr<RigidBodyTreed> model = ddModel.getDrakeRBM();
   Vector3d normal; for (int i=0; i<normal_in.size(); i++) normal[i] = normal_in[i];
   Vector3d point_on_contact_plane; for (int i=0; i<point_on_contact_plane_in.size(); i++) point_on_contact_plane[i] = point_on_contact_plane_in[i];
   std::vector<ForceTorqueMeasurement> force_torque_measurements;


### PR DESCRIPTION
This PR depends on Drake's PR in RobotLocomotion/drake#3969. That PR must be merged before this one.

This PR simply replaces all the occurrences of `RigidBodyTree` with `RigidBodyTreed`. Per RobotLocomotion/drake#3969, `RigidBodyTreed` simply is a typedef to `RigidBodyTree`.

When RobotLocomotion/drake#3940 the typedef, from Drake's side, will be updated to `RigidBodyTree<double>`.
