### PR TITLE
Deactivate auto-start of Kinect when useKinect is activated

### DIFF
--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -1053,7 +1053,7 @@ if useCourseModel:
 if useKinect:
     import kinectlcm
     imageOverlayManager.viewName = "KINECT_RGB"
-    kinectlcm.startButton()
+    #kinectlcm.startButton()
 
 if 'startup' in drcargs.args():
     for filename in drcargs.args().startup:


### PR DESCRIPTION
Currently when useKinect is set it automatically starts the listener and update which is heavy on the CPU. Deactivate by default.

Merging as this is minor and only used locally for two projects (and we've changed the default behavior with a previous PR a few days ago)