### PR TITLE
Fix default constraint creation for mobile, fixed, humanoid robots

### DIFF
--- a/src/python/director/ikplanner.py
+++ b/src/python/director/ikplanner.py
@@ -756,9 +756,7 @@ class IKPlanner(object):
 
 
     def createMovingBodyConstraints(self, startPoseName, lockBase=False, lockBack=False, lockLeftArm=False, lockRightArm=False):
-
-        if (self.fixedBaseArm==False):
-
+        if not self.fixedBaseArm and not self.robotNoFeet:
             constraints = []
             if self.useQuasiStaticConstraint:
                 constraints.append(self.createQuasiStaticConstraint())
@@ -770,6 +768,7 @@ class IKPlanner(object):
             else:
                 constraints.append(self.createMovingBackPostureConstraint())
 
+        if not self.fixedBaseArm:
             if lockBase:
                 constraints.append(self.createLockedBasePostureConstraint(startPoseName))
             else:
@@ -781,7 +780,7 @@ class IKPlanner(object):
             if lockRightArm:
                 constraints.append(self.createLockedRightArmPostureConstraint(startPoseName))
 
-        else: # Remove all except the fixed base constraint if you only have an arm:
+        if self.fixedBaseArm: # Remove all except the fixed base constraint if you only have an arm:
             constraints = []
             constraints.append(self.createLockedBasePostureConstraint(startPoseName))
 

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -167,6 +167,7 @@ useCourseModel = False
 useLimitJointsSentToPlanner = False
 useOpenniDepthImage = False
 useKinect = False
+useFeetlessRobot = False
 
 poseCollection = PythonQt.dd.ddSignalMap()
 costCollection = PythonQt.dd.ddSignalMap()
@@ -1054,6 +1055,9 @@ if useKinect:
     import kinectlcm
     imageOverlayManager.viewName = "KINECT_RGB"
     #kinectlcm.startButton()
+
+if useFeetlessRobot:
+    ikPlanner.robotNoFeet = True
 
 if 'startup' in drcargs.args():
     for filename in drcargs.args().startup:

--- a/src/python/director/teleoppanel.py
+++ b/src/python/director/teleoppanel.py
@@ -432,8 +432,8 @@ class EndEffectorTeleopPanel(object):
         startPose = self.panel.planningUtils.getPlanningStartPose()
         ikPlanner.addPose(startPose, startPoseName)
 
-        if (ikPlanner.fixedBaseArm==False):
-
+        # Humanoid, i.e. robot has feet and is not a fixed base arm
+        if not ikPlanner.fixedBaseArm and not ikPlanner.robotNoFeet:
             constraints = []
             constraints.append(ikPlanner.createQuasiStaticConstraint())
             constraints.append(ikPlanner.createLockedNeckPostureConstraint(startPoseName))
@@ -452,7 +452,6 @@ class EndEffectorTeleopPanel(object):
             elif self.getRFootConstraint() == 'sliding':
                 constraints.extend(ikPlanner.createSlidingFootConstraints(startPoseName)[2:])
 
-
             if self.getBackConstraint() == 'fixed':
                 constraints.append(ikPlanner.createLockedBackPostureConstraint(startPoseName))
                 ikPlanner.setBackLocked(True)
@@ -462,7 +461,6 @@ class EndEffectorTeleopPanel(object):
             elif self.getBackConstraint() == 'free':
                 constraints.append(ikPlanner.createMovingBackPostureConstraint())
                 ikPlanner.setBackLocked(False)
-
 
             if self.getBaseConstraint() == 'fixed':
                 constraints.append(ikPlanner.createLockedBasePostureConstraint(startPoseName, lockLegs=False))
@@ -486,15 +484,17 @@ class EndEffectorTeleopPanel(object):
                 constraints.append(ikPlanner.createKneePostureConstraint(self.kneeJointLimits))
                 ikPlanner.setBaseLocked(False)
 
-        # Remove all except the fixed base constraint if you only have an arm:
-        else:
+        # Fixed Base Arm: Remove all except the fixed base constraint
+        if ikPlanner.fixedBaseArm:
             constraints = []
             constraints.append(ikPlanner.createLockedBasePostureConstraint(startPoseName, lockLegs=False))
 
-
-        if ikPlanner.robotNoFeet == True:
+        if ikPlanner.robotNoFeet:
             constraints = []
             constraints.append(ikPlanner.createLockedBasePostureConstraint(startPoseName))
+
+        # Only add Back constraints if robot has a back
+        if ikPlanner.getJointGroup('Back'):
             if self.getBackConstraint() == 'fixed':
                 constraints.append(ikPlanner.createLockedBackPostureConstraint(startPoseName))
                 ikPlanner.setBackLocked(True)


### PR DESCRIPTION
- Only create back constraints if the robot has back joints specified in the director config
- Add flag to be able to set ``ikPlanner.robotNoFeet`` from director config via the startup.py component enable/disable

@patmarion would you mind having a look at this whether this is okay/as intended? Using it here to fix teleop planning for a mobile/floating base non-humanoid robot. Tested with val and lwr to verify those still work