### PR TITLE
remove usage of child frame objects for links in drake-visualizer

### DIFF
--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -284,7 +284,7 @@ class Link(object):
     def setTransform(self, pos, quat):
         self.transform = transformUtils.transformFromPose(pos, quat)
         for g in self.geometry:
-            g.polyDataItem.getChildFrame().copyFrame(self.transform)
+            g.polyDataItem.actor.SetUserTransform(self.transform)
 
 
 class DrakeVisualizer(object):
@@ -353,7 +353,6 @@ class DrakeVisualizer(object):
     def addLinkGeometry(self, geom, linkName, linkFolder):
         geom.polyDataItem.addToView(self.view)
         om.addToObjectModel(geom.polyDataItem, parentObj=linkFolder)
-        vis.addChildFrame(geom.polyDataItem)
 
         if linkName == 'world':
             #geom.polyDataItem.actor.SetUseBounds(False)
@@ -424,7 +423,7 @@ class DrakeVisualizer(object):
 
                 linkFolder = self.getLinkFolder(robotNum, linkName)
                 self.addLinkGeometry(g, linkName, linkFolder)
-                g.polyDataItem.getChildFrame().copyFrame(link.transform)
+                g.polyDataItem.actor.SetUserTransform(link.transform)
 
             points = vtk.vtkPoints()
             verts = vtk.vtkCellArray()


### PR DESCRIPTION
The callbacks associated with child frames do not scale well for greater
than a few hundred instances, and there are now users of drake visualizer
that are generating hundreds of links.

Perhaps in the future I'll optimize the frame callbacks, but for now I am
just removing child frames from the implementation.