### PR TITLE
if a child frame exists then use it

### DIFF
--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -284,7 +284,11 @@ class Link(object):
     def setTransform(self, pos, quat):
         self.transform = transformUtils.transformFromPose(pos, quat)
         for g in self.geometry:
-            g.polyDataItem.actor.SetUserTransform(self.transform)
+            childFrame = g.polyDataItem.getChildFrame()
+            if childFrame:
+                childFrame.copyFrame(self.transform)
+            else:
+                g.polyDataItem.actor.SetUserTransform(self.transform)
 
 
 class DrakeVisualizer(object):


### PR DESCRIPTION
this code was recently modified to optimize the viewer for scenes with
many links.  but the camera follower needs to use child frames.

fixes #378.