### PR TITLE
changes needed for a non-humanoid, non-OH, non-planning mobile robot - a Husky

### DIFF
--- a/src/python/director/atlasdriver.py
+++ b/src/python/director/atlasdriver.py
@@ -18,7 +18,7 @@ import time
 
 import drc as lcmdrc
 import bot_core
-import atlas
+#import atlas
 from pronto.indexed_measurement_t import indexed_measurement_t
 
 

--- a/src/python/director/continuouswalkingdemo.py
+++ b/src/python/director/continuouswalkingdemo.py
@@ -5,7 +5,6 @@ import operator
 import vtkAll as vtk
 import vtkNumpy
 import functools
-import ihmc
 
 from director import lcmUtils
 from director import ioUtils
@@ -26,7 +25,8 @@ import director.tasks.robottasks as rt
 
 import drc as lcmdrc
 import bot_core
-import atlas
+#import atlas
+#import ihmc
 
 from thirdparty import qhull_2d
 from thirdparty import min_bounding_rect

--- a/src/python/director/handdriver.py
+++ b/src/python/director/handdriver.py
@@ -16,8 +16,8 @@ from director.simpletimer import SimpleTimer
 from director.utime import getUtime
 from director import robotstate
 
-import irobothand as lcmirobot
-import robotiqhand as lcmrobotiq
+#import irobothand as lcmirobot
+#import robotiqhand as lcmrobotiq
 
 
 class IRobotHandDriver(object):

--- a/src/python/director/irisUtils.py
+++ b/src/python/director/irisUtils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import drc as lcmdrc
-from irispy.utils import lcon_to_vert
+#from irispy.utils import lcon_to_vert
 from director.lcmframe import frameFromPositionMessage, positionMessageFromFrame
 from scipy.spatial import ConvexHull
 

--- a/src/python/director/robotsystem.py
+++ b/src/python/director/robotsystem.py
@@ -33,7 +33,7 @@ class RobotSystemFactory(ComponentFactory):
         #addComponent('FootstepsPlayback', ['Footsteps', 'Playback'])
         addComponent('Affordances', [])
         #addComponent('PlannerPublisher', ['Planning', 'Affordances'])
-        #addComponent('ViewBehaviors', ['Footsteps', 'PerceptionDrivers', 'Planning'])
+        addComponent('ViewBehaviors', ['PerceptionDrivers'])
 
     def initDirectorConfig(self, robotSystem):
 

--- a/src/python/director/robotsystem.py
+++ b/src/python/director/robotsystem.py
@@ -9,7 +9,7 @@ class RobotSystemFactory(ComponentFactory):
         Components are enabled by default.  This function
         determines which components should be disabled.
         '''
-        options.useConvexHullModel = False
+        #options.useConvexHullModel = False
 
     def addComponents(self, componentGraph):
 
@@ -24,16 +24,16 @@ class RobotSystemFactory(ComponentFactory):
         addComponent('HandDrivers', [])
         addComponent('Footsteps', ['RobotState'])
         addComponent('RaycastDriver', ['Footsteps'])
-        addComponent('IRISDriver', ['RobotState', 'Footsteps'])
-        addComponent('AtlasDriver', [])
+        #addComponent('IRISDriver', ['RobotState', 'Footsteps'])
+        #addComponent('AtlasDriver', [])
         addComponent('Planning', ['RobotState'])
-        addComponent('Playback', ['Planning'])
-        addComponent('Teleop', ['Planning', 'Playback', 'Affordances'])
-        addComponent('ConvexHullModel', ['Playback'])
-        addComponent('FootstepsPlayback', ['Footsteps', 'Playback'])
+        #addComponent('Playback', ['Planning'])
+        #addComponent('Teleop', ['Planning', 'Playback', 'Affordances'])
+        #addComponent('ConvexHullModel', ['Playback'])
+        #addComponent('FootstepsPlayback', ['Footsteps', 'Playback'])
         addComponent('Affordances', [])
-        addComponent('PlannerPublisher', ['Planning', 'Affordances'])
-        addComponent('ViewBehaviors', ['Footsteps', 'PerceptionDrivers', 'Planning'])
+        #addComponent('PlannerPublisher', ['Planning', 'Affordances'])
+        #addComponent('ViewBehaviors', ['Footsteps', 'PerceptionDrivers', 'Planning'])
 
     def initDirectorConfig(self, robotSystem):
 

--- a/src/python/director/robotviewbehaviors.py
+++ b/src/python/director/robotviewbehaviors.py
@@ -665,7 +665,7 @@ class RobotViewBehaviors(object):
         robotSystem = _robotSystem
         robotModel = robotSystem.robotStateModel
         handFactory = robotSystem.handFactory
-        footstepsDriver = robotSystem.footstepsDriver
+        #footstepsDriver = robotSystem.footstepsDriver
         neckDriver = robotSystem.neckDriver
         if app.getMainWindow() is not None:
             robotLinkSelector = RobotLinkSelector()

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -103,7 +103,6 @@ from director.tasks.descriptions import loadTaskDescriptions
 import drc as lcmdrc
 import bot_core as lcmbotcore
 import maps as lcmmaps
-import atlas
 
 from collections import OrderedDict
 import functools

--- a/src/python/director/terrain.py
+++ b/src/python/director/terrain.py
@@ -5,10 +5,10 @@ from scipy.spatial import ConvexHull
 
 from director.irisUtils import SafeTerrainRegion
 from director import transformUtils
-from irispy.utils import sample_convex_polytope
-import polyhedron._cdd
-from polyhedron import Vrep, Hrep
-from py_drake_utils.utils import rpy2rotmat
+#from irispy.utils import sample_convex_polytope
+#import polyhedron._cdd
+#from polyhedron import Vrep, Hrep
+#from py_drake_utils.utils import rpy2rotmat
 
 FOOTSIZE_REDUCTION = 0.04
 FOOT_LENGTH = 0.25 - FOOTSIZE_REDUCTION


### PR DESCRIPTION
**This isn't intended to be merged - I'm looking for feedback on should be done with each issue**

The following is a very brief set of changes needed to do the above - which makes the Director fully usable to operate & visualise mobile robots. It is possible with the latest updates from @patmarion 

**Goal**
We don't need/want the following and disabled them in the relevant config.json (which is all fine and expected): planning, DRC demos, IK, AtlasDriver, footsteps

**Issues**
1. I modified addComponent to disable things I don't want, but I do want viewbehaviors 
   - Presumably this can be tailored to a specific robot somehow and not changed like this?
   - I had to make one modification to robotviewbehaviors to remove footstepsDriver

2. A key issue is Iris. It has 3 dependencies and I believe we don't use it:
   - irispy which is used for 1 call each to sample_convex_polytope() and lcon_to_vert()
   - polyhedron - 3 commit repo. Suggestion: insert directly into Director
   - py_drake_utils - only used for one call to rpy2rotmat (which is duplicately implemented in bdi footstep planner)

3. I had to disable this, but would like to keep it: convexhull
I then had to comment out the line in initDefaultOptions calling it 'has no attribute useConvexHullModel'
What is this?

4. Imports of lcmtypes which don't exist:
atlasdriver.py
   - imports atlas lcmtypes
handdriver.py
   - imports irobot and robotiq hand types
Continuous walking demo:
   - imports atlas and ihmc lcmtypes
These could be fixed by using "if available, import"