### PR TITLE
Support adding and removing robots in drakevisualizer

### DIFF
--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -304,6 +304,8 @@ class DrakeVisualizer(object):
 
     def _addSubscribers(self):
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_LOAD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerLoadRobot))
+        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_ADD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerAddRobot))
+        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_REMOVE_ROBOT', lcmrl.utime_t, self.onViewerRemoveRobot))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_DRAW', lcmrl.viewer_draw_t, self.onViewerDraw))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_PLANAR_LIDAR_.*', lcmbot.planar_lidar_t, self.onPlanarLidar, callbackNeedsChannel=True))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_POINTCLOUD_.*', lcmbot.pointcloud_t, self.onPointCloud, callbackNeedsChannel=True))
@@ -330,11 +332,19 @@ class DrakeVisualizer(object):
 
     def onViewerLoadRobot(self, msg):
         self.removeAllRobots()
-        for link in msg.link:
-            l = Link(link)
-            self.addLink(l, link.robot_num, link.name)
-
+        self.addLinksFromLCM(msg)
         self.sendStatusMessage('successfully loaded robot')
+
+    def onViewerAddRobot(self, msg):
+        robotNumsToReplace = set(link.robot_num for link in msg.link)
+        for robotNum in robotNumsToReplace:
+            self.removeRobot(robotNum)
+        self.addLinksFromLCM(msg)
+        self.sendStatusMessage('successfully added robot')
+
+    def onViewerRemoveRobot(self, msg):
+        self.removeRobot(msg.utime)
+        self.sendStatusMessage('successfully removed robot')
 
     def getRootFolder(self):
         return om.getOrCreateContainer('drake viewer', parentObj=om.findObjectByName('scene'))
@@ -347,6 +357,10 @@ class DrakeVisualizer(object):
 
     def getPointCloudFolder(self):
         return om.getOrCreateContainer('pointclouds', parentObj=self.getRootFolder())
+
+    def addLinksFromLCM(self, load_msg):
+        for link in load_msg.link:
+            self.addLink(Link(link), link.robot_num, link.name)
 
     def addLink(self, link, robotNum, linkName):
         self.robots.setdefault(robotNum, {})[linkName] = link
@@ -374,6 +388,9 @@ class DrakeVisualizer(object):
             if child.getProperty('Name') != "pointclouds":
                 om.removeFromObjectModel(child)
         self.robots = {}
+
+    def removeRobot(self, robotNum):
+        om.removeFromObjectModel(self.getRobotFolder(robotNum))
 
     def sendStatusMessage(self, message):
         msg = lcmrl.viewer_command_t()

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -343,7 +343,10 @@ class DrakeVisualizer(object):
         self.sendStatusMessage('successfully added robot')
 
     def onViewerRemoveRobot(self, msg):
-        self.removeRobot(msg.utime)
+        if msg.utime >= 0:
+            self.removeRobot(msg.utime)
+        else:
+            self.removeAllRobots()
         self.sendStatusMessage('successfully removed robot')
 
     def getRootFolder(self):

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -305,7 +305,6 @@ class DrakeVisualizer(object):
     def _addSubscribers(self):
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_LOAD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerLoadRobot))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_ADD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerAddRobot))
-        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_REMOVE_ROBOT', lcmrl.utime_t, self.onViewerRemoveRobot))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_DRAW', lcmrl.viewer_draw_t, self.onViewerDraw))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_PLANAR_LIDAR_.*', lcmbot.planar_lidar_t, self.onPlanarLidar, callbackNeedsChannel=True))
         self.subscribers.append(lcmUtils.addSubscriber('DRAKE_POINTCLOUD_.*', lcmbot.pointcloud_t, self.onPointCloud, callbackNeedsChannel=True))
@@ -341,13 +340,6 @@ class DrakeVisualizer(object):
             self.removeRobot(robotNum)
         self.addLinksFromLCM(msg)
         self.sendStatusMessage('successfully added robot')
-
-    def onViewerRemoveRobot(self, msg):
-        if msg.utime >= 0:
-            self.removeRobot(msg.utime)
-        else:
-            self.removeAllRobots()
-        self.sendStatusMessage('successfully removed robot')
 
     def getRootFolder(self):
         return om.getOrCreateContainer('drake viewer', parentObj=om.findObjectByName('scene'))

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -390,7 +390,9 @@ class DrakeVisualizer(object):
         self.robots = {}
 
     def removeRobot(self, robotNum):
-        om.removeFromObjectModel(self.getRobotFolder(robotNum))
+        if robotNum in self.robots:
+            om.removeFromObjectModel(self.getRobotFolder(robotNum))
+            del self.robots[robotNum]
 
     def sendStatusMessage(self, message):
         msg = lcmrl.viewer_command_t()


### PR DESCRIPTION
Fixes #389 

drakevisualizer now listens to `DRAKE_VIEWER_ADD_ROBOT` ~~and DRAKE_VIEWER_REMOVE_ROBOT~~. `ADD_ROBOT` has the same message type as the existing `LOAD_ROBOT`, but does not clear existing robots (unless an existing robot has the same robot ID number as the robot being added). ~~REMOVE_ROBOT just includes a single robot ID number to delete, or -1 to delete all robots.~~

~~Note: I am abusing the LCM `utime_t` here as the message type for `REMOVE_ROBOT`, in order to avoid creating a branch new LCM type just to send an integer. This feels gross, but I think I'm OK with it~~