### PR TITLE
Updated URDFRigidBodyTreeVTK to Call URDF Parser Directly.

### DIFF
--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -1,15 +1,10 @@
 #include "ddDrakeModel.h"
 #include "ddSharedPtr.h"
 
-#ifdef DRAKE_OH_FORK
-#include <drake/systems/plants/RigidBodyTree.h>
-#include <drake/systems/plants/shapes/Geometry.h>
-#else
 #include <drake/multibody/joints/floating_base_types.h>
 #include <drake/multibody/parser_urdf.h>
 #include <drake/multibody/rigid_body_tree.h>
 #include <drake/multibody/shapes/geometry.h>
-#endif
 
 #include <vtkPolyData.h>
 #include <vtkAppendPolyData.h>
@@ -740,14 +735,10 @@ URDFRigidBodyTreeVTK::Ptr loadVTKModelFromXML(const QString& xmlString, const QS
 {
   URDFRigidBodyTreeVTK::Ptr model(new URDFRigidBodyTreeVTK);
 
-#ifdef DRAKE_OH_FORK
-  model->addRobotFromURDFString(xmlString.toUtf8().constData(), PackageSearchPaths, rootDir.toLatin1().constData());
-#else
   drake::parsers::urdf::AddModelInstanceFromUrdfStringSearchingInRosPackages(
       xmlString.toUtf8().constData(), PackageSearchPaths,
       rootDir.toLatin1().constData(), drake::multibody::joints::kRollPitchYaw,
       nullptr /* weld to frame */, model.get());
-#endif
 
   model->computeDofMap();
   model->loadVisuals(rootDir);

--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -5,6 +5,8 @@
 #include <drake/systems/plants/RigidBodyTree.h>
 #include <drake/systems/plants/shapes/Geometry.h>
 #else
+#include <drake/multibody/joints/floating_base_types.h>
+#include <drake/multibody/parser_urdf.h>
 #include <drake/multibody/rigid_body_tree.h>
 #include <drake/multibody/shapes/geometry.h>
 #endif
@@ -737,7 +739,16 @@ public:
 URDFRigidBodyTreeVTK::Ptr loadVTKModelFromXML(const QString& xmlString, const QString& rootDir="")
 {
   URDFRigidBodyTreeVTK::Ptr model(new URDFRigidBodyTreeVTK);
+
+#ifdef DRAKE_OH_FORK
   model->addRobotFromURDFString(xmlString.toUtf8().constData(), PackageSearchPaths, rootDir.toLatin1().constData());
+#else
+  drake::parsers::urdf::AddModelInstanceFromUrdfStringSearchingInRosPackages(
+      xmlString.toUtf8().constData(), PackageSearchPaths,
+      rootDir.toLatin1().constData(), drake::multibody::joints::kRollPitchYaw,
+      nullptr /* weld to frame */, model.get());
+#endif
+
   model->computeDofMap();
   model->loadVisuals(rootDir);
   return model;


### PR DESCRIPTION
In Drake, I'm working on establishing a layering rule where the URDF and SDF parsers depend on `RigidBodyTree` and not vice versa. For background and motivation, see https://github.com/RobotLocomotion/drake/pull/4317#issuecomment-264149254. This PR modifies Director to conform to this layering design.