### PR TITLE
Updates to use RBT::CreateKinematicsCache()

### DIFF
--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -901,7 +901,8 @@ void ddDrakeModel::setJointPositions(const QVector<double>& jointPositions)
 
   this->Internal->JointPositions = jointPositions;
 
-  model->cache = std::make_shared<KinematicsCache<double> >(model->bodies);
+  model->cache = std::make_shared<KinematicsCache<double> >(
+      model->CreateKinematicsCache());
   model->cache->initialize(q);
   model->doKinematics(*model->cache);
   model->updateModel();


### PR DESCRIPTION
Constructor for `KinematicsCache` from a list of bodies will no longer be available to break the dependency of `KinematicsCache` on `RigidBody`. Per RobotLocomotion/drake#4378, `RigidBodyTree` manages the creation of a proper cache. 
This PR updates director to use that new API.