### PR TITLE
Updates Director to use Drake's new PackageMap class.

### DIFF
--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -2,6 +2,7 @@
 #include "ddSharedPtr.h"
 
 #include <drake/multibody/joints/floating_base_types.h>
+#include <drake/multibody/package_map.h>
 #include <drake/multibody/parser_urdf.h>
 #include <drake/multibody/rigid_body_tree.h>
 #include <drake/multibody/shapes/geometry.h>
@@ -86,7 +87,7 @@ namespace
 
 const int GRAY_DEFAULT = 190;
 
-std::map<std::string, std::string> PackageSearchPaths;
+drake::parsers::PackageMap PackageSearchPaths;
 
 int feq (double a, double b)
 {
@@ -1342,18 +1343,18 @@ bool ddDrakeModel::visible() const
 void ddDrakeModel::addPackageSearchPath(const QString& searchPath)
 {
   std::string packageName = QDir(searchPath).dirName().toAscii().data();
-  if (PackageSearchPaths.count(packageName) == 0)
+  if (!PackageSearchPaths.Contains(packageName))
   {
-    PackageSearchPaths[packageName] = searchPath.toAscii().data();
+    PackageSearchPaths.Add(packageName, searchPath.toAscii().data());
   }
 }
 
 //-----------------------------------------------------------------------------
 QString ddDrakeModel::findPackageDirectory(const QString& packageName)
 {
-  auto packageDirIter = PackageSearchPaths.find(packageName.toAscii().data());
-  if (packageDirIter != PackageSearchPaths.end()) {
-    return QString::fromStdString(packageDirIter->second);
+  const std::string package_name = packageName.toAscii().data();
+  if (PackageSearchPaths.Contains(package_name)) {
+    return QString::fromStdString(PackageSearchPaths.GetPath(package_name));
   } else {
     return QString();
   }

--- a/src/python/director/pydrakeik.py
+++ b/src/python/director/pydrakeik.py
@@ -203,9 +203,9 @@ class PyDrakeIkServer(object):
 
         assert os.path.isfile(urdfFile)
 
-        packageMap = pydrake.rbtree.mapStringString()
+        packageMap = pydrake.rbtree.PackageMap()
         for path in packagePaths:
-            packageMap[os.path.basename(path)] = path
+            packageMap.Add(os.path.basename(path), path)
 
         urdfString = open(urdfFile, 'r').read()
         baseDir = str(os.path.dirname(urdfFile))


### PR DESCRIPTION
In https://github.com/RobotLocomotion/drake/pull/4363, @jwnimmer-tri recommended that we switch from using a `PackageMap` of type `std::map<string, string>` to a dedicated class.

See: https://reviewable.io/reviews/RobotLocomotion/drake/4363#-KYZFibpGHR_kRG_OCOm

This PR updates Director to use this new `PackageMap`. It should not be merged until after https://github.com/RobotLocomotion/drake/pull/4363 is merged.