### PR TITLE
in copy_files.sh, ensure that ~/.ssh exists

### DIFF
--- a/distro/travis/copy_files.sh
+++ b/distro/travis/copy_files.sh
@@ -8,5 +8,6 @@ chmod 600 $scriptDir/travisci.key
 dest=$encrypted_copyfiles_host
 user=travis
 
+mkdir -p ~/.ssh
 ssh-keyscan -H $dest >> ~/.ssh/known_hosts
 scp -i $scriptDir/travisci.key $* $user@$dest:files/


### PR DESCRIPTION
it doesn't exist by default on the docker ubuntu image