### PR TITLE
Shiny new drake visualizer

### DIFF
--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -146,7 +146,7 @@ if (USE_LCM)
 
   ExternalProject_Add(bot_core_lcmtypes
     GIT_REPOSITORY https://github.com/rdeits/bot_core_lcmtypes
-    GIT_TAG 9446ce422b679e88968718f63715c681cf621b70
+    GIT_TAG dd1236b5bf5f2662e200d78297393333fe97ae64
     ${cmake3_args}
     CMAKE_CACHE_ARGS
       ${default_cmake_args}

--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -145,8 +145,8 @@ endif()
 if (USE_LCM)
 
   ExternalProject_Add(bot_core_lcmtypes
-    GIT_REPOSITORY https://github.com/openhumanoids/bot_core_lcmtypes
-    GIT_TAG 9967654
+    GIT_REPOSITORY https://github.com/rdeits/bot_core_lcmtypes
+    GIT_TAG 9446ce422b679e88968718f63715c681cf621b70
     ${cmake3_args}
     CMAKE_CACHE_ARGS
       ${default_cmake_args}

--- a/newviewer.py
+++ b/newviewer.py
@@ -4,7 +4,7 @@ import time
 import math
 import sys
 import numpy as np
-sys.path.append("build/install/lib/python2.7/site-packages")
+sys.path.append("build/install/lib/python2.7/dist-packages")
 
 import lcm
 import bot_core
@@ -96,52 +96,50 @@ class Visualizer:
 if __name__ == '__main__':
     geometries = [{
             "name": "box",
-            "type": "box",
             "pose": {
                 "translation": [0, 0, 0],
                 "quaternion": [1, 0, 0, 0]
             },
+            "color": [0, 1, 0, 0.5],
             "parameters": {
-                "color": [0, 1, 0, 0.5],
+                "type": "box",
                 "lengths": [1, 1, 1]
             },
         },
         {
             "name": "box2",
-            "type": "box",
             "pose": {
                 "translation": [1, 0, 0],
                 "quaternion": [1, 0, 0, 0]
             },
+            "color": [0, 0, 1, 0.5],
             "parameters": {
-                "color": [0, 0, 1, 0.5],
+                "type": "box",
                 "lengths": [1, 1, 1]
             }
         },
         {
             "name": "points",
-            "type": "pointcloud",
             "pose": {
                 "translation": [1, 0, 0],
                 "quaternion": [1, 0, 0, 0]
             },
             "parameters": {
+                "type": "pointcloud",
                 "points": [[0, 0, 2 + x / 100.] for x in range(100)],
                 "channels": {
-                    "r": [x / 100. for x in range(100)],
-                    "g": [1 - x / 100. for x in range(100)],
-                    "b": [x / 100. for x in range(100)]
+                    "rgb": [[x / 100., 1 - x / 100., x / 100.] for x in range(100)]
                 }
             }
         },
         {
             "name": "planar lidar",
-            "type": "planar_lidar",
             "pose": {
                 "translation": [0, 2, 0],
                 "quaternion": [1, 0, 0, 0]
             },
             "parameters": {
+                "type": "planar_lidar",
                 "angle_start": -np.pi/2,
                 "angle_step": np.pi / 100,
                 "ranges": [1 for i in range(100)],

--- a/newviewer.py
+++ b/newviewer.py
@@ -35,6 +35,7 @@ class Visualizer:
             self.lcm.handle_timeout(10)
 
     def load(self):
+        print "Loading model"
         timestamp = 0
         data = {
             "timestamp": timestamp,
@@ -68,13 +69,24 @@ class Visualizer:
         msg = comms_msg(timestamp, data)
         self.lcm.publish("DRAKE_VIEWER2_REQUEST", msg.encode())
 
+    def delete(self):
+        timestamp = 0
+        data = {
+            "timestamp": timestamp,
+            "type": "delete",
+            "data": {
+                "paths": [self.path]
+            }
+        }
+        msg = comms_msg(timestamp, data)
+        self.lcm.publish("DRAKE_VIEWER2_REQUEST", msg.encode())
+
     def onResponse(self, channel, raw_data):
         msg = bot_core.viewer2_comms_t.decode(raw_data)
         data = json.loads(msg.data)
         if data["status"] == 0:
             return
         elif data["status"] == 1:
-            print "Loading model"
             self.load()
         else:
             print "Warning: unhandled failure: ", data
@@ -123,13 +135,18 @@ if __name__ == '__main__':
         },
         ]
     vis = Visualizer(["robot1", "link1"], geometries)
-    # vis.load()
-    while True:
-        for i in range(1000):
-            x = math.sin(math.pi * 2 * i / 1000.0)
-            pose = {
-                "translation": [x, 0, 0],
-                "quaternion": [1, 0, 0, 0]
-            }
-            vis.draw(pose)
-            time.sleep(0.001)
+    vis.load()
+    try:
+        while True:
+            for i in range(1000):
+                x = math.sin(math.pi * 2 * i / 1000.0)
+                pose = {
+                    "translation": [x, 0, 0],
+                    "quaternion": [1, 0, 0, 0]
+                }
+                vis.draw(pose)
+                time.sleep(0.001)
+    except:
+        # vis.delete()
+        raise
+

--- a/newviewer.py
+++ b/newviewer.py
@@ -67,8 +67,10 @@ class Visualizer:
         })
 
     def delete(self, path):
-        del self.poses[path]
-        del self.geometries[path]
+        if path in self.poses:
+            del self.poses[path]
+        if path in self.geometries:
+            del self.geometries[path]
         self.queue["delete"].append({
             "path": path.split("/")
         })
@@ -132,6 +134,10 @@ if __name__ == '__main__':
                 vis.publish()
                 time.sleep(0.001)
     except:
-        # vis.delete()
+        print "deleting"
+        paths = vis.geometries.keys()
+        for path in paths:
+            vis.delete(path)
+        vis.publish()
         raise
 

--- a/newviewer.py
+++ b/newviewer.py
@@ -100,8 +100,8 @@ if __name__ == '__main__':
                 "translation": [0, 0, 0],
                 "quaternion": [1, 0, 0, 0]
             },
-            "color": [0, 1, 0, 0.5],
             "parameters": {
+                "color": [0, 1, 0, 0.5],
                 "type": "box",
                 "lengths": [1, 1, 1]
             },
@@ -112,8 +112,8 @@ if __name__ == '__main__':
                 "translation": [1, 0, 0],
                 "quaternion": [1, 0, 0, 0]
             },
-            "color": [0, 0, 1, 0.5],
             "parameters": {
+                "color": [0, 0, 1, 0.5],
                 "type": "box",
                 "lengths": [1, 1, 1]
             }

--- a/newviewer.py
+++ b/newviewer.py
@@ -70,9 +70,7 @@ class Visualizer:
 
     def onResponse(self, channel, raw_data):
         msg = bot_core.viewer2_comms_t.decode(raw_data)
-        print "response data:", msg.data
         data = json.loads(msg.data)
-        print "decoded"
         if data["status"] == 0:
             return
         elif data["status"] == 1:
@@ -83,19 +81,48 @@ class Visualizer:
 
 
 if __name__ == '__main__':
-    geometry = {
-        "name": "box",
-        "type": "box",
-        "pose": {
-            "translation": [0, 0, 0],
-            "quaternion": [1, 0, 0, 0]
+    geometries = [{
+            "name": "box",
+            "type": "box",
+            "pose": {
+                "translation": [0, 0, 0],
+                "quaternion": [1, 0, 0, 0]
+            },
+            "parameters": {
+                "color": [0, 1, 0, 0.5],
+                "lengths": [1, 1, 1]
+            },
         },
-        "color": [1, 0, 0, 0.5],
-        "parameters": {
-            "lengths": [1, 1, 1]
-        }
-    }
-    vis = Visualizer(["robot1", "link1"], [geometry])
+        {
+            "name": "box2",
+            "type": "box",
+            "pose": {
+                "translation": [1, 0, 0],
+                "quaternion": [1, 0, 0, 0]
+            },
+            "parameters": {
+                "color": [0, 0, 1, 0.5],
+                "lengths": [1, 1, 1]
+            }
+        },
+        {
+            "name": "points",
+            "type": "pointcloud",
+            "pose": {
+                "translation": [1, 0, 0],
+                "quaternion": [1, 0, 0, 0]
+            },
+            "parameters": {
+                "points": [[0, 0, 2 + x / 100.] for x in range(100)],
+                "channels": {
+                    "r": [x / 100. for x in range(100)],
+                    "g": [1 - x / 100. for x in range(100)],
+                    "b": [x / 100. for x in range(100)]
+                }
+            }
+        },
+        ]
+    vis = Visualizer(["robot1", "link1"], geometries)
     # vis.load()
     while True:
         for i in range(1000):

--- a/newviewer.py
+++ b/newviewer.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import threading
 import time
@@ -8,15 +7,6 @@ sys.path.append("build/install/lib/python2.7/site-packages")
 
 import lcm
 import bot_core
-
-
-# def to_pose_3d(trans, quat):
-#     msg = bot_core.position_3d_t()
-#     msg.translation = bot_core.vector_3d_t()
-#     msg.translation.x, msg.translation.y, msg.translation.z = trans
-#     msg.rotation = bot_core.quaternion_t()
-#     msg.rotation.w, msg.rotation.x, msg.rotation.y, msg.rotation.z = quat
-#     return msg
 
 
 def comms_msg(timestamp, data):
@@ -105,29 +95,6 @@ if __name__ == '__main__':
             "lengths": [1, 1, 1]
         }
     }
-    # geometry_data = bot_core.viewer2_geometry_data_t()
-    # geometry_data.name = "box"
-    # geometry_data.pose = to_pose_3d([0, 0, 0], [1, 0, 0, 0])
-    # geometry_data.color = [1.0, 0, 0, 0.5]
-    # geometry_data.format = "json"
-    # geometry_data.format_version = 1
-
-    # geom = {
-    #     "type": "box",
-    #     "parameters": {
-    #         "lengths": [1, 1, 1]
-    #     }
-    # }
-    # data = json.dumps(geom)
-    # geometry_data.num_bytes = len(data)
-    # geometry_data.data = data
-    # geometry_data = bot_core.viewer_geometry_data_t()
-    # geometry_data.type = geometry_data.BOX
-    # geometry_data.position = [0, 0, 0]
-    # geometry_data.quaternion = [1, 0, 0, 0]
-    # geometry_data.color = [1, 0, 0, 0.5]
-    # geometry_data.num_float_data = 3
-    # geometry_data.float_data = [1, 1, 1]
     vis = Visualizer(["robot1", "link1"], [geometry])
     # vis.load()
     while True:

--- a/newviewer.py
+++ b/newviewer.py
@@ -1,0 +1,75 @@
+import hashlib
+import json
+import threading
+import time
+import math
+import sys
+sys.path.append("build/install/lib/python2.7/site-packages")
+
+import lcm
+import bot_core
+
+
+class Visualizer:
+    def __init__(self, path, geometries):
+        self.path = path
+        self.geometries = geometries
+        self.lcm = lcm.LCM()
+        self.lcm.subscribe("DRAKE_VIEWER2_RESPONSE", self.onResponse)
+        self.listener = threading.Thread(target=self.listen)
+        self.listener.daemon = True
+        self.listener.start()
+
+    def listen(self):
+        while True:
+            self.lcm.handle_timeout(10)
+
+    def load(self):
+        link_data = bot_core.viewer2_link_data_t()
+        link_data.num_geometries = 1
+        link_data.geometries = self.geometries
+        link_data.path = self.path
+
+        load_msg = bot_core.viewer2_load_links_t()
+        load_msg.num_links = 1
+        load_msg.link_data = [link_data]
+        self.lcm.publish("DRAKE_VIEWER2_LOAD_LINKS", load_msg.encode())
+
+    def draw(self, pose):
+        draw_msg = bot_core.viewer2_draw_t()
+        draw_msg.num_links = 1
+        draw_msg.poses = [pose]
+        draw_msg.paths = [self.path]
+        self.lcm.publish("DRAKE_VIEWER2_DRAW", draw_msg.encode())
+
+    def onResponse(self, channel, data):
+        msg = bot_core.viewer2_response_t.decode(data)
+        if msg.status == msg.STATUS_OK:
+            return
+        elif msg.status == msg.STATUS_NO_SUCH_LINK:
+            print "Loading model"
+            self.load()
+        else:
+            print "Warning: unhandled failure: ", msg.status, json.loads(msg.json)
+
+
+if __name__ == '__main__':
+    geometry_data = bot_core.viewer_geometry_data_t()
+    geometry_data.type = geometry_data.BOX
+    geometry_data.position = [0, 0, 0]
+    geometry_data.quaternion = [1, 0, 0, 0]
+    geometry_data.color = [1, 0, 0, 0.5]
+    geometry_data.num_float_data = 3
+    geometry_data.float_data = [1, 1, 1]
+    vis = Visualizer("robot1/link1", [geometry_data])
+    while True:
+        for i in range(1000):
+            trans = bot_core.vector_3d_t()
+            trans.x = math.sin(math.pi * 2 * i / 1000.0)
+            quat = bot_core.quaternion_t()
+            quat.w = 1
+            pose = bot_core.position_3d_t()
+            pose.translation = trans
+            pose.rotation = quat
+            vis.draw(pose)
+            time.sleep(0.001)

--- a/newviewer.py
+++ b/newviewer.py
@@ -125,19 +125,27 @@ if __name__ == '__main__':
     try:
         while True:
             for i in range(1000):
-                x = math.sin(math.pi * 2 * i / 1000.0)
+                x1 = math.sin(math.pi * 2 * i / 1000.0)
                 pose = {
-                    "translation": [x, 0, 0],
+                    "translation": [x1, 0, 0],
                     "quaternion": [1, 0, 0, 0]
                 }
                 vis.draw("robot1/link1", pose)
+
+                x2 = math.sin(math.pi * 2 * i / 500.0)
+                pose = {
+                    "translation": [x2, 0, 0],
+                    "quaternion": [1, 0, 0, 0]
+                }
+                vis.draw("robot1/link1/box1", pose)
+
                 vis.publish()
                 time.sleep(0.001)
     except:
-        print "deleting"
-        paths = vis.geometries.keys()
-        for path in paths:
-            vis.delete(path)
-        vis.publish()
+        # print "deleting"
+        # paths = vis.geometries.keys()
+        # for path in paths:
+        #     vis.delete(path)
+        # vis.publish()
         raise
 

--- a/newviewer.py
+++ b/newviewer.py
@@ -10,6 +10,26 @@ import lcm
 import bot_core
 
 
+# def to_pose_3d(trans, quat):
+#     msg = bot_core.position_3d_t()
+#     msg.translation = bot_core.vector_3d_t()
+#     msg.translation.x, msg.translation.y, msg.translation.z = trans
+#     msg.rotation = bot_core.quaternion_t()
+#     msg.rotation.w, msg.rotation.x, msg.rotation.y, msg.rotation.z = quat
+#     return msg
+
+
+def comms_msg(timestamp, data):
+    msg = bot_core.viewer2_comms_t()
+    msg.format = "viewer2_json"
+    msg.format_version_major = 1
+    msg.format_version_minor = 0
+    encoded = json.dumps(data)
+    msg.num_bytes = len(encoded)
+    msg.data = encoded
+    return msg
+
+
 class Visualizer:
     def __init__(self, path, geometries):
         self.path = path
@@ -25,51 +45,97 @@ class Visualizer:
             self.lcm.handle_timeout(10)
 
     def load(self):
-        link_data = bot_core.viewer2_link_data_t()
-        link_data.num_geometries = 1
-        link_data.geometries = self.geometries
-        link_data.path = self.path
-
-        load_msg = bot_core.viewer2_load_links_t()
-        load_msg.num_links = 1
-        load_msg.link_data = [link_data]
-        self.lcm.publish("DRAKE_VIEWER2_LOAD_LINKS", load_msg.encode())
+        timestamp = 0
+        data = {
+            "timestamp": timestamp,
+            "type": "load",
+            "data": {
+                "links": [
+                    {
+                        "path": self.path,
+                        "geometries": self.geometries
+                    }
+                ]
+            }
+        }
+        msg = comms_msg(timestamp, data)
+        self.lcm.publish("DRAKE_VIEWER2_REQUEST", msg.encode())
 
     def draw(self, pose):
-        draw_msg = bot_core.viewer2_draw_t()
-        draw_msg.num_links = 1
-        draw_msg.poses = [pose]
-        draw_msg.paths = [self.path]
-        self.lcm.publish("DRAKE_VIEWER2_DRAW", draw_msg.encode())
+        timestamp = 0
+        data = {
+            "timestamp": timestamp,
+            "type": "draw",
+            "data": {
+                "commands": [
+                    {
+                        "path": self.path,
+                        "pose": pose
+                    }
+                ]
+            }
+        }
+        msg = comms_msg(timestamp, data)
+        self.lcm.publish("DRAKE_VIEWER2_REQUEST", msg.encode())
 
-    def onResponse(self, channel, data):
-        msg = bot_core.viewer2_response_t.decode(data)
-        if msg.status == msg.STATUS_OK:
+    def onResponse(self, channel, raw_data):
+        msg = bot_core.viewer2_comms_t.decode(raw_data)
+        print "response data:", msg.data
+        data = json.loads(msg.data)
+        print "decoded"
+        if data["status"] == 0:
             return
-        elif msg.status == msg.STATUS_NO_SUCH_LINK:
+        elif data["status"] == 1:
             print "Loading model"
             self.load()
         else:
-            print "Warning: unhandled failure: ", msg.status, json.loads(msg.json)
+            print "Warning: unhandled failure: ", data
 
 
 if __name__ == '__main__':
-    geometry_data = bot_core.viewer_geometry_data_t()
-    geometry_data.type = geometry_data.BOX
-    geometry_data.position = [0, 0, 0]
-    geometry_data.quaternion = [1, 0, 0, 0]
-    geometry_data.color = [1, 0, 0, 0.5]
-    geometry_data.num_float_data = 3
-    geometry_data.float_data = [1, 1, 1]
-    vis = Visualizer("robot1/link1", [geometry_data])
+    geometry = {
+        "name": "box",
+        "type": "box",
+        "pose": {
+            "translation": [0, 0, 0],
+            "quaternion": [1, 0, 0, 0]
+        },
+        "color": [1, 0, 0, 0.5],
+        "parameters": {
+            "lengths": [1, 1, 1]
+        }
+    }
+    # geometry_data = bot_core.viewer2_geometry_data_t()
+    # geometry_data.name = "box"
+    # geometry_data.pose = to_pose_3d([0, 0, 0], [1, 0, 0, 0])
+    # geometry_data.color = [1.0, 0, 0, 0.5]
+    # geometry_data.format = "json"
+    # geometry_data.format_version = 1
+
+    # geom = {
+    #     "type": "box",
+    #     "parameters": {
+    #         "lengths": [1, 1, 1]
+    #     }
+    # }
+    # data = json.dumps(geom)
+    # geometry_data.num_bytes = len(data)
+    # geometry_data.data = data
+    # geometry_data = bot_core.viewer_geometry_data_t()
+    # geometry_data.type = geometry_data.BOX
+    # geometry_data.position = [0, 0, 0]
+    # geometry_data.quaternion = [1, 0, 0, 0]
+    # geometry_data.color = [1, 0, 0, 0.5]
+    # geometry_data.num_float_data = 3
+    # geometry_data.float_data = [1, 1, 1]
+    vis = Visualizer(["robot1", "link1"], [geometry])
+    # vis.load()
     while True:
         for i in range(1000):
-            trans = bot_core.vector_3d_t()
-            trans.x = math.sin(math.pi * 2 * i / 1000.0)
-            quat = bot_core.quaternion_t()
-            quat.w = 1
-            pose = bot_core.position_3d_t()
-            pose.translation = trans
-            pose.rotation = quat
+            x = math.sin(math.pi * 2 * i / 1000.0)
+            pose = {
+                "translation": [x, 0, 0],
+                "quaternion": [1, 0, 0, 0]
+            }
             vis.draw(pose)
             time.sleep(0.001)

--- a/newviewer.py
+++ b/newviewer.py
@@ -3,6 +3,7 @@ import threading
 import time
 import math
 import sys
+import numpy as np
 sys.path.append("build/install/lib/python2.7/site-packages")
 
 import lcm
@@ -130,6 +131,22 @@ if __name__ == '__main__':
                     "r": [x / 100. for x in range(100)],
                     "g": [1 - x / 100. for x in range(100)],
                     "b": [x / 100. for x in range(100)]
+                }
+            }
+        },
+        {
+            "name": "planar lidar",
+            "type": "planar_lidar",
+            "pose": {
+                "translation": [0, 2, 0],
+                "quaternion": [1, 0, 0, 0]
+            },
+            "parameters": {
+                "angle_start": -np.pi/2,
+                "angle_step": np.pi / 100,
+                "ranges": [1 for i in range(100)],
+                "channels": {
+                    "intensity": [i / 100. for i in range(100)]
                 }
             }
         },

--- a/src/app/drakeVisualizerApp.cpp
+++ b/src/app/drakeVisualizerApp.cpp
@@ -8,7 +8,13 @@ int main(int argc, char **argv)
   ddPythonManager* pythonManager = new ddPythonManager;
   pythonManager->setSysArgv(QApplication::instance()->arguments());
   PythonQt::self()->addVariable(PythonQt::self()->importModule("sys"), "executable", QCoreApplication::applicationFilePath());
-  pythonManager->executeString("import director.drakevisualizer; director.drakevisualizer.main(globals())");
+
+  if (argc > 1 && strcmp(argv[1], "-v2") == 0) {
+    pythonManager->executeString("import director.drakevisualizerapp2; director.drakevisualizerapp2.main(globals())");
+  } else {
+    pythonManager->executeString("import director.drakevisualizerapp1; director.drakevisualizerapp1.main(globals())");
+  }
+
 
   // delete pythonManager;
   // Allow a leak to avoid a segfault in the PythonQt cleanup destructor.

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -33,6 +33,10 @@ set(python_files
   director/depthscanner.py
   director/doordemo.py
   director/drakevisualizer.py
+  director/drakevisualizer2.py
+  director/drakevisualizerapp.py
+  director/drakevisualizerapp1.py
+  director/drakevisualizerapp2.py
   director/drcargs.py
   director/drilldemo.py
   director/drivingplanner.py

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -133,41 +133,6 @@ class Geometry(object):
                 "Unsupported geometry type: {}".format(geom["type"]))
 
     # @staticmethod
-    # def createPolyDataFromPrimitive(geom):
-
-    #     if geom.type == lcmrl.viewer_geometry_data_t.BOX:
-    #         d = DebugData()
-    #         d.addCube(dimensions=geom.float_data[0:3], center=[0,0,0])
-    #         return d.getPolyData()
-
-    #     elif geom.type == lcmrl.viewer_geometry_data_t.SPHERE:
-    #         d = DebugData()
-    #         d.addSphere(center=(0,0,0), radius=geom.float_data[0])
-    #         return d.getPolyData()
-
-    #     elif geom.type == lcmrl.viewer_geometry_data_t.CYLINDER:
-    #         d = DebugData()
-    #         d.addCylinder(center=(0,0,0), axis=(0,0,1), radius=geom.float_data[0], length=geom.float_data[1])
-    #         return d.getPolyData()
-
-    #     elif geom.type == lcmrl.viewer_geometry_data_t.CAPSULE:
-    #         d = DebugData()
-    #         radius = geom.float_data[0]
-    #         length = geom.float_data[1]
-    #         d.addCylinder(center=(0,0,0), axis=(0,0,1), radius=radius, length=length)
-    #         d.addSphere(center=(0,0,length/2.0), radius=radius)
-    #         d.addSphere(center=(0,0,-length/2.0), radius=radius)
-    #         return d.getPolyData()
-
-    #     elif hasattr(lcmrl.viewer_geometry_data_t, "ELLIPSOID") and geom.type == lcmrl.viewer_geometry_data_t.ELLIPSOID:
-    #         d = DebugData()
-    #         radii = geom.float_data[0:3]
-    #         d.addEllipsoid(center=(0,0,0), radii=radii)
-    #         return d.getPolyData()
-
-    #     raise Exception('Unsupported geometry type: %s' % geom.type)
-
-    # @staticmethod
     # def createPolyDataFromMeshMessage(geom):
 
     #     assert len(geom.float_data) >= 2
@@ -461,10 +426,6 @@ class DrakeVisualizer(object):
             'DRAKE_VIEWER2_REQUEST',
             lcmrl.viewer2_comms_t,
             self.onViewerRequest))
-        # self.subscribers.append(lcmUtils.addSubscriber(
-        #     'DRAKE_VIEWER2_DRAW',
-        #     lcmrl.viewer2_comms_t,
-        #     self.onViewerDraw))
 
         # self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_LOAD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerLoadRobot))
         # self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_ADD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerAddRobot))
@@ -537,46 +498,14 @@ class DrakeVisualizer(object):
         elif data["type"] == "draw":
             return self.drawLinks(data["data"])
 
-    # def onViewerLoadLinks(self, msg):
-    #     if msg.format == "viewer2_json":
-    #         if msg.format_version_major == 1 and msg.format_version_minor == 0:
-    #             data = json.loads(msg.data)
-    #             try:
-    #                 self.loadLinks(data)
-    #             except Exception as e:
-    #                 self.sendStatusMessage(
-    #                     msg.timestamp,
-    #                     ERROR_LOADING,
-    #                     {"error": str(e)})
-    #                 print e
-    #             else:
-    #                 self.sendStatusMessage(
-    #                     msg.timestamp,
-    #                     OK,
-    #                     {"loaded_paths": [l["path"] for l in data["links"]]})
-    #         else:
-    #             self.sendStatusMessage(
-    #                 msg.timestamp,
-    #                 ERROR_UNKNOWN_FORMAT_VERSION,
-    #                 {"supported_formats": {
-    #                     "viewer2_json": [{"major": 1, "minor": 0}]
-    #                 }})
-    #     else:
-    #         self.sendStatusMessage(
-    #             msg.timestamp,
-    #             ERROR_UNKNOWN_FORMAT,
-    #             {"supported_formats": {
-    #                 "viewer2_json": [{"major": 1, "minor": 0}]
-    #             }})
-
     def loadLinks(self, data):
-        # try:
+        try:
             for linkData in data["links"]:
                 self.loadLinkData(linkData)
-        # except Exception as e:
-        #     raise e
-        #     return ViewerResponse(ERROR_HANDLING_REQUEST, {"error": str(e)})
-        # else:
+        except Exception as e:
+            print e
+            return ViewerResponse(ERROR_HANDLING_REQUEST, {"error": str(e)})
+        else:
             return ViewerResponse(OK, {})
 
     def loadLinkData(self, linkData):
@@ -654,7 +583,7 @@ class DrakeVisualizer(object):
             else:
                 return ViewerResponse(OK, {})
         except Exception as e:
-            raise e
+            print e
             return ViewerResponse(ERROR_HANDLING_REQUEST,
                                   {"error": str(e)})
 

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -1,8 +1,5 @@
-import math
-import os
-import json
+import math, os
 import numpy as np
-from collections import namedtuple
 from director import lcmUtils
 
 import director.objectmodel as om
@@ -31,130 +28,67 @@ from PythonQt import QtGui
 USE_TEXTURE_MESHES = True
 USE_SHADOWS = False
 
-
-class ViewerStatus:
-    OK = 0
-    MISSING_PATHS = 1
-    ERROR_UNKNOWN_FORMAT = -1
-    ERROR_UNKNOWN_FORMAT_VERSION = -2
-    ERROR_HANDLING_REQUEST = -3
-    ERROR_UKNOWN_REQUEST_TYPE = -4
-
-
-class ViewerResponse(namedtuple("ViewerResponse", ["status", "data"])):
-    def toJson(self):
-        return dict(status=self.status, **self.data)
-
-
-def transformFromDict(pose_data):
-    return transformUtils.transformFromPose(
-        pose_data.get("translation", [0, 0, 0]),
-        pose_data.get("quaternion", [1, 0, 0, 0]))
-
-
 class Geometry(object):
+
     TextureCache = {}
+    MeshToTexture = {}
+
     PackageMap = None
 
     @staticmethod
-    def createBox(params):
-        d = DebugData()
-        d.addCube(dimensions=params["lengths"], center=(0, 0, 0))
-        return [d.getPolyData()]
+    def createPolyDataFromPrimitive(geom):
+
+        if geom.type == lcmrl.viewer_geometry_data_t.BOX:
+            d = DebugData()
+            d.addCube(dimensions=geom.float_data[0:3], center=[0,0,0])
+            return d.getPolyData()
+
+        elif geom.type == lcmrl.viewer_geometry_data_t.SPHERE:
+            d = DebugData()
+            d.addSphere(center=(0,0,0), radius=geom.float_data[0])
+            return d.getPolyData()
+
+        elif geom.type == lcmrl.viewer_geometry_data_t.CYLINDER:
+            d = DebugData()
+            d.addCylinder(center=(0,0,0), axis=(0,0,1), radius=geom.float_data[0], length=geom.float_data[1])
+            return d.getPolyData()
+
+        elif geom.type == lcmrl.viewer_geometry_data_t.CAPSULE:
+            d = DebugData()
+            radius = geom.float_data[0]
+            length = geom.float_data[1]
+            d.addCylinder(center=(0,0,0), axis=(0,0,1), radius=radius, length=length)
+            d.addSphere(center=(0,0,length/2.0), radius=radius)
+            d.addSphere(center=(0,0,-length/2.0), radius=radius)
+            return d.getPolyData()
+
+        elif hasattr(lcmrl.viewer_geometry_data_t, "ELLIPSOID") and geom.type == lcmrl.viewer_geometry_data_t.ELLIPSOID:
+            d = DebugData()
+            radii = geom.float_data[0:3]
+            d.addEllipsoid(center=(0,0,0), radii=radii)
+            return d.getPolyData()
+
+        raise Exception('Unsupported geometry type: %s' % geom.type)
 
     @staticmethod
-    def createSphere(params):
-        d = DebugData()
-        d.addSphere(center=(0, 0, 0), radius=params["radius"])
-        return [d.getPolyData()]
+    def createPolyDataFromMeshMessage(geom):
 
-    @staticmethod
-    def createCylinder(params):
-        d = DebugData()
-        d.addCylinder(center=(0, 0, 0),
-                      axis=(0, 0, 1),
-                      radius=params["radius"],
-                      length=params["length"])
-        return [d.getPolyData()]
+        assert len(geom.float_data) >= 2
 
-    @staticmethod
-    def createCapsule(params):
-        d = DebugData()
-        radius = params["radius"]
-        length = params["length"]
-        d.addCylinder(center=(0, 0, 0),
-                      axis=(0, 0, 1),
-                      radius=radius,
-                      length=length)
-        d.addSphere(center=(0, 0, length / 2.0), radius=radius)
-        d.addSphere(center=(0, 0, -length / 2.0), radius=radius)
-        return [d.getPolyData()]
+        numPoints = int(geom.float_data[0])
+        numTris = int(geom.float_data[1])
 
-    @staticmethod
-    def createEllipsoid(params):
-        d = DebugData()
-        radii = params["radii"]
-        d.addEllipsoid(center=(0, 0, 0), radii=radii)
-        return [d.getPolyData()]
+        headerOffset = 2
+        ptsOffset = 3*numPoints
+        trisOffset = 3*numTris
 
-    @staticmethod
-    def createMeshFromFile(params):
-        polyDataList = Geometry.loadPolyDataMeshes(params["filename"])
-        if "scale" in params:
-            polyDataList = Geometry.scaleGeometry(polyDataList,
-                                                  params["scale"])
-        return polyDataList
+        assert len(geom.float_data) == headerOffset + ptsOffset + trisOffset
 
-    @staticmethod
-    def createMeshFromData(params):
-        verts = np.asarray(params["vertices"])
-        faces = np.asarray(params["faces"])
-        return [Geometry.createPolyDataFromMeshArrays(verts, faces)]
+        pts = np.array(geom.float_data[headerOffset:headerOffset+ptsOffset])
+        pts = pts.reshape((numPoints, 3))
+        tris = np.array(geom.float_data[headerOffset+ptsOffset:], dtype=int)
 
-    @staticmethod
-    def createPointcloud(params):
-        polyData = vnp.numpyToPolyData(np.asarray(params["points"]),
-                                       createVertexCells=True)
-        return [polyData]
-
-    @staticmethod
-    def createPlanarLidar(params):
-        ranges = np.asarray(params["ranges"])
-        angle_stop = (params["angle_start"] +
-                      len(ranges) * params["angle_step"])
-        angles = np.arange(
-            params["angle_start"],
-            angle_stop,
-            params["angle_step"])
-        x = ranges * np.cos(angles)
-        y = ranges * np.sin(angles)
-        z = np.zeros(x.shape)
-        points = np.vstack((x, y, z)).T
-        return [vnp.numpyToPolyData(points, createVertexCells=True)]
-
-    @staticmethod
-    def createPolyData(params):
-        if params["type"] == "box":
-            return Geometry.createBox(params)
-        elif params["type"] == "sphere":
-            return Geometry.createSphere(params)
-        elif params["type"] == "cylinder":
-            return Geometry.createCylinder(params)
-        elif params["type"] == "capsule":
-            return Geometry.createCapsule(params)
-        elif params["type"] == "ellipsoid":
-            return Geometry.createEllipsoid(params)
-        elif params["type"] == "mesh_file":
-            return Geometry.createMeshFromFile(params)
-        elif params["type"] == "mesh_data":
-            return Geometry.createMeshFromData(params)
-        elif params["type"] == "pointcloud":
-            return Geometry.createPointcloud(params)
-        elif params["type"] == "planar_lidar":
-            return Geometry.createPlanarLidar(params)
-        else:
-            raise Exception(
-                "Unsupported geometry type: {}".format(params["type"]))
+        return Geometry.createPolyDataFromMeshArrays(pts, tris)
 
     @staticmethod
     def createPolyDataFromMeshArrays(pts, faces):
@@ -162,24 +96,28 @@ class Geometry(object):
         pd.SetPoints(vtk.vtkPoints())
         pd.GetPoints().SetData(vnp.getVtkFromNumpy(pts.copy()))
 
+        assert len(faces) % 3 == 0
         cells = vtk.vtkCellArray()
-        for face in faces:
-            assert len(face) == 3, "Non-triangular faces are not supported."
+        for i in xrange(len(faces)/3):
             tri = vtk.vtkTriangle()
-            tri.GetPointIds().SetId(0, face[0])
-            tri.GetPointIds().SetId(1, face[1])
-            tri.GetPointIds().SetId(2, face[2])
+            tri.GetPointIds().SetId(0, faces[i*3 + 0])
+            tri.GetPointIds().SetId(1, faces[i*3 + 1])
+            tri.GetPointIds().SetId(2, faces[i*3 + 2])
             cells.InsertNextCell(tri)
 
         pd.SetPolys(cells)
         return pd
 
     @staticmethod
-    def scaleGeometry(polyDataList, scale):
-        if len(scale) == 1:
-            scale_x = scale_y = scale_z = scale
+    def scaleGeometry(polyDataList, geom):
+        if len(geom.float_data) == 1:
+            scale_x = scale_y = scale_z = geom.float_data[0]
         elif len(geom.float_data) == 3:
-            scale_x, scale_y, scale_z = scale
+            scale_x = geom.float_data[0]
+            scale_y = geom.float_data[1]
+            scale_z = geom.float_data[2]
+        else:
+            scale_x = scale_y = scale_z = 1.0
 
         if scale_x != 1.0 or scale_y != 1.0 or scale_z != 1.0:
             t = vtk.vtkTransform()
@@ -187,6 +125,14 @@ class Geometry(object):
             polyDataList = [filterUtils.transformPolyData(polyData, t) for polyData in polyDataList]
 
         return polyDataList
+
+
+    @staticmethod
+    def transformGeometry(polyDataList, geom):
+        t = transformUtils.transformFromPose(geom.position, geom.quaternion)
+        polyDataList = [filterUtils.transformPolyData(polyData, t) for polyData in polyDataList]
+        return polyDataList
+
 
     @staticmethod
     def computeNormals(polyDataList):
@@ -250,9 +196,9 @@ class Geometry(object):
         return Geometry.PackageMap.resolveFilename(filename) or filename
 
     @staticmethod
-    def loadPolyDataMeshes(filename):
+    def loadPolyDataMeshes(geom):
 
-        filename = Geometry.resolvePackageFilename(filename)
+        filename = Geometry.resolvePackageFilename(geom.string_data)
         basename, ext = os.path.splitext(filename)
 
         preferredExtensions = ['.vtm', '.vtp', '.obj']
@@ -275,87 +221,93 @@ class Geometry(object):
             for polyData in polyDataList:
                 Geometry.loadTextureForMesh(polyData, filename)
 
+
         return polyDataList
+
 
     @staticmethod
     def createPolyDataForGeometry(geom):
-        polyDataList = Geometry.createPolyData(geom)
+
+        polyDataList = []
+
+        if geom.type != lcmrl.viewer_geometry_data_t.MESH:
+            polyDataList = [Geometry.createPolyDataFromPrimitive(geom)]
+
+        else:
+            if not geom.string_data:
+                polyDataList = [Geometry.createPolyDataFromMeshMessage(geom)]
+            else:
+                polyDataList = Geometry.loadPolyDataMeshes(geom)
+                polyDataList = Geometry.scaleGeometry(polyDataList, geom)
+
+        polyDataList = Geometry.transformGeometry(polyDataList, geom)
         polyDataList = Geometry.computeNormals(polyDataList)
+
         return polyDataList
 
     @staticmethod
-    def createGeometry(geom):
+    def createGeometry(name, geom, parentTransform):
         polyDataList = Geometry.createPolyDataForGeometry(geom)
 
         geometry = []
         for polyData in polyDataList:
-            g = Geometry(geom, polyData)
+            g = Geometry(name, geom, polyData, parentTransform)
             geometry.append(g)
         return geometry
 
-    @staticmethod
-    def addColorChannels(polyData, channels):
-        if "intensity" in channels:
-            colorBy = "intensity"
-            intensity = np.asarray(channels["intensity"]) * 255
-            vnp.addNumpyToVtk(polyData,
-                              intensity.astype(np.uint8),
-                              "intensity")
-        if "rgb" in channels:
-            colorBy = "rgb"  # default to rgb if provided
-            colorArray = np.asarray(channels["rgb"]) * 255
-            vnp.addNumpyToVtk(polyData, colorArray.astype(np.uint8), "rgb")
 
-    def __init__(self, geomData, polyData):
-        if "channels" in geomData:
-            Geometry.addColorChannels(polyData, geomData["channels"])
-        self.polyDataItem = vis.PolyDataItem("geometry", polyData, view=None)
-        self.polyDataItem._updateColorByProperty()
-
-        color = geomData.get("color", [1, 0, 0, 0.5])
-        self.polyDataItem.setProperty('Alpha', color[3])
-        self.polyDataItem.actor.SetTexture(
-            Geometry.TextureCache.get(
-                Geometry.getTextureFileName(polyData)))
+    def __init__(self, name, geom, polyData, parentTransform):
+        self.polyDataItem = vis.PolyDataItem(name, polyData, view=None)
+        self.polyDataItem.setProperty('Alpha', geom.color[3])
+        self.polyDataItem.actor.SetTexture(Geometry.TextureCache.get( Geometry.getTextureFileName(polyData) ))
 
         if self.polyDataItem.actor.GetTexture():
-            self.polyDataItem.setProperty('Color',
-                                          QtGui.QColor(255, 255, 255))
+            self.polyDataItem.setProperty('Color', QtGui.QColor(255, 255, 255))
+
         else:
-            self.polyDataItem.setProperty(
-                'Color',
-                QtGui.QColor(*(255 * np.asarray(color[:3]))))
+            self.polyDataItem.setProperty('Color', QtGui.QColor(geom.color[0]*255, geom.color[1]*255, geom.color[2]*255))
 
         if USE_SHADOWS:
             self.polyDataItem.shadowOn()
 
 
-def findPathToAncestor(fromItem, toItem):
-    path = [fromItem]
-    while fromItem is not toItem:
-        parent = fromItem.parent()
-        if parent is None:
-            raise ValueError(
-                "Cannot find a path from {} to {}".format(fromItem, toItem))
-        path.append(parent)
-        fromItem = parent
-    return path
+class Link(object):
+
+    def __init__(self, link):
+        self.transform = vtk.vtkTransform()
+
+        self.geometry = []
+        for g in link.geom:
+            self.geometry.extend(Geometry.createGeometry(link.name + ' geometry data', g, self.transform))
+
+
+    def setTransform(self, pos, quat):
+        self.transform = transformUtils.transformFromPose(pos, quat)
+        for g in self.geometry:
+            childFrame = g.polyDataItem.getChildFrame()
+            if childFrame:
+                childFrame.copyFrame(self.transform)
+            else:
+                g.polyDataItem.actor.SetUserTransform(self.transform)
 
 
 class DrakeVisualizer(object):
+
     def __init__(self, view):
 
         self.subscribers = []
         self.view = view
+        self.robots = {}
+        self.linkWarnings = set()
         self.enable()
-        self.sendStatusMessage(
-            0, ViewerResponse(ViewerStatus.OK, {"ready": True}))
+        self.sendStatusMessage('loaded')
 
     def _addSubscribers(self):
-        self.subscribers.append(lcmUtils.addSubscriber(
-            'DRAKE_VIEWER2_REQUEST',
-            lcmrl.viewer2_comms_t,
-            self.onViewerRequest))
+        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_LOAD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerLoadRobot))
+        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_ADD_ROBOT', lcmrl.viewer_load_robot_t, self.onViewerAddRobot))
+        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_VIEWER_DRAW', lcmrl.viewer_draw_t, self.onViewerDraw))
+        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_PLANAR_LIDAR_.*', lcmbot.planar_lidar_t, self.onPlanarLidar, callbackNeedsChannel=True))
+        self.subscribers.append(lcmUtils.addSubscriber('DRAKE_POINTCLOUD_.*', lcmbot.pointcloud_t, self.onPointCloud, callbackNeedsChannel=True))
 
     def _removeSubscribers(self):
         for sub in self.subscribers:
@@ -377,364 +329,170 @@ class DrakeVisualizer(object):
     def disable(self):
         self.setEnabled(False)
 
-    def sendStatusMessage(self, timestamp, response):
-        msg = lcmrl.viewer2_comms_t()
-        msg.format = "viewer2_json"
-        msg.format_version_major = 1
-        msg.format_version_minor = 0
-        data = dict(timestamp=timestamp, **response.toJson())
-        print "responding:", data
-        msg.data = json.dumps(data)
-        msg.num_bytes = len(msg.data)
-        lcmUtils.publish('DRAKE_VIEWER2_RESPONSE', msg)
+    def onViewerLoadRobot(self, msg):
+        self.removeAllRobots()
+        self.addLinksFromLCM(msg)
+        self.sendStatusMessage('successfully loaded robot')
 
-    def decodeCommsMsg(self, msg):
-        if msg.format == "viewer2_json":
-            if msg.format_version_major == 1 and msg.format_version_minor == 0:
-                data = json.loads(msg.data)
-                return data, ViewerResponse(ViewerStatus.OK, {})
-            else:
-                return None, ViewerResponse(ViewerStatus.ERROR_UNKNOWN_FORMAT_VERSION,
-                                            {"supported_formats": {
-                                                 "viewer2_json": [{"major": 1,
-                                                                   "minor": 0}]
-                                            }})
-        else:
-            return None, ViewerResponse(ViewerStatus.ERROR_UNKNOWN_FORMAT,
-                                        {"supported_formats": {
-                                             "viewer2_json": [{"major": 1,
-                                                               "minor": 0}]
-                                        }})
-
-    def onViewerRequest(self, msg):
-        data, response = self.decodeCommsMsg(msg)
-        if data is None:
-            self.sendStatusMessage(msg.timestamp,
-                                   [responses])
-        else:
-            responses = self.handleViewerRequest(data)
-            self.sendStatusMessage(msg.timestamp,
-                                   responses)
-
-    def handleViewerRequest(self, data):
-        result = {
-            "deleted_paths": [],
-            "added_geometries": [],
-            "set_transforms": [],
-            "missing_paths": []
-        }
-        for command in data["delete"]:
-            print "delete:", command["path"]
-            result["deleted_paths"].append(self.handleDeletePath(command))
-        for command in data["load"]:
-            print "load:", command["path"]
-            result["added_geometries"].append(self.handleAddGeometry(command))
-        for command in data["draw"]:
-            print "draw:", command["path"]
-            path, missingGeometry = self.handleSetTransform(command)
-            result["set_transforms"].append(path)
-            if missingGeometry:
-                result["missing_paths"].append(path)
-        if not result["missing_paths"]:
-            return ViewerResponse(ViewerStatus.OK, result)
-        else:
-            return ViewerResponse(ViewerStatus.MISSING_PATHS, result)
-
-    def handleAddGeometry(self, command):
-        path = command["path"]
-        vtkGeoms = Geometry.createGeometry(command["geometry"])
-        return self.addGeometry(path, vtkGeoms)
-
-    def addGeometry(self, path, geomItems):
-        folder = self.getPathFolder(path)
-        ancestors = findPathToAncestor(folder, self.getRootFolder())
-        geomTransform = vtk.vtkTransform()
-        for item in reversed(ancestors):
-            if not hasattr(item, "transform"):
-                item.transform = vtk.vtkTransform()
-                item.transform.PostMultiply()
-            geomTransform.Concatenate(item.transform)
-
-        for geom in geomItems:
-            existing_item = self.getItemByPath(path + ["geometry"])
-            item = geom.polyDataItem
-            if existing_item is not None:
-                for prop in existing_item.propertyNames():
-                    item.setProperty(prop, existing_item.getProperty(prop))
-                om.removeFromObjectModel(existing_item)
-            else:
-                item.setProperty("Point Size", 2)
-                for colorBy in ["rgb", "intensity"]:
-                    try:
-                        item.setProperty("Color By", colorBy)
-                    except ValueError:
-                        pass
-                    else:
-                        break
-
-            item.addToView(self.view)
-            om.addToObjectModel(item, parentObj=folder)
-            item.actor.SetUserTransform(geomTransform)
-
-        return path
-
-    def getPathForItem(self, item):
-        return [x.getProperty("Name") for x in reversed(findPathToAncestor(
-            item, self.getRootFolder())[:-1])]
-
-    def handleSetTransform(self, command):
-        return self._setTransform(command["path"],
-                                  transformFromDict(command["transform"]))
-
-    def _setTransform(self, path, transform):
-        folder = self.getPathFolder(path)
-        if not hasattr(folder, "transform"):
-            folder.transform = transform
-        else:
-            folder.transform.SetMatrix(transform.GetMatrix())
-        self.view.render()
-        return path, len(folder.children()) == 0
-
-    def handleDeletePath(self, command):
-        path = command["path"]
-        item = self.getItemByPath(path)
-        if item is not None:
-            om.removeFromObjectModel(item)
-        return path
+    def onViewerAddRobot(self, msg):
+        robotNumsToReplace = set(link.robot_num for link in msg.link)
+        for robotNum in robotNumsToReplace:
+            self.removeRobot(robotNum)
+        self.addLinksFromLCM(msg)
+        self.sendStatusMessage('successfully added robot')
 
     def getRootFolder(self):
-        return om.getOrCreateContainer('drake viewer',
-                                       parentObj=om.findObjectByName('scene'))
+        return om.getOrCreateContainer('drake viewer', parentObj=om.findObjectByName('scene'))
 
-    def getItemByPath(self, path):
-        item = self.getRootFolder()
-        for element in path:
-            item = item.findChild(element)
-            if item is None:
-                return None
-        return item
+    def getRobotFolder(self, robotNum):
+        return om.getOrCreateContainer('robot %d' % robotNum, parentObj=self.getRootFolder())
 
-    def getPathFolder(self, path):
-        folder = self.getRootFolder()
-        for element in path:
-            folder = om.getOrCreateContainer(element, parentObj=folder)
-        return folder
+    def getLinkFolder(self, robotNum, linkName):
+        return om.getOrCreateContainer(linkName, parentObj=self.getRobotFolder(robotNum))
 
+    def getPointCloudFolder(self):
+        return om.getOrCreateContainer('pointclouds', parentObj=self.getRootFolder())
 
-##########################################################
-from director.screengrabberpanel import ScreenGrabberPanel
-from director import lcmgl
-from director import objectmodel as om
-from director import applogic
-from director import appsettings
-from director import viewbehaviors
-from director import camerabookmarks
-from director import cameracontrolpanel
-import PythonQt
-from PythonQt import QtCore, QtGui
+    def addLinksFromLCM(self, load_msg):
+        for link in load_msg.link:
+            self.addLink(Link(link), link.robot_num, link.name)
 
+    def addLink(self, link, robotNum, linkName):
+        self.robots.setdefault(robotNum, {})[linkName] = link
+        linkFolder = self.getLinkFolder(robotNum, linkName)
+        for geom in link.geometry:
+            self.addLinkGeometry(geom, linkName, linkFolder)
 
-class DrakeVisualizerApp():
+    def addLinkGeometry(self, geom, linkName, linkFolder):
+        geom.polyDataItem.addToView(self.view)
+        om.addToObjectModel(geom.polyDataItem, parentObj=linkFolder)
 
-    def __init__(self):
+        if linkName == 'world':
+            #geom.polyDataItem.actor.SetUseBounds(False)
+            #geom.polyDataItem.actor.GetProperty().LightingOff()
+            geom.polyDataItem.actor.GetProperty().SetSpecular(0.0)
+        else:
+            geom.polyDataItem.actor.GetProperty().SetSpecular(0.9)
+            geom.polyDataItem.actor.GetProperty().SetSpecularPower(20)
 
-        self.applicationInstance().setOrganizationName('RobotLocomotionGroup')
-        self.applicationInstance().setApplicationName('drake-visualizer')
+    def getLink(self, robotNum, linkName):
+        return self.robots[robotNum][linkName]
 
-        om.init()
-        self.view = PythonQt.dd.ddQVTKWidgetView()
+    def removeAllRobots(self):
+        for child in self.getRootFolder().children():
+            if child.getProperty('Name') != "pointclouds":
+                om.removeFromObjectModel(child)
+        self.robots = {}
 
-        # init grid
-        self.gridObj = vis.showGrid(self.view, parent='scene')
-        self.gridObj.setProperty('Surface Mode', 'Surface with edges')
-        self.gridObj.setProperty('Color', [0,0,0])
-        self.gridObj.setProperty('Alpha', 0.1)
+    def removeRobot(self, robotNum):
+        if robotNum in self.robots:
+            om.removeFromObjectModel(self.getRobotFolder(robotNum))
+            del self.robots[robotNum]
 
-        # init view options
-        self.viewOptions = vis.ViewOptionsItem(self.view)
-        om.addToObjectModel(self.viewOptions, parentObj=om.findObjectByName('scene'))
-        self.viewOptions.setProperty('Background color', [0.3, 0.3, 0.35])
-        self.viewOptions.setProperty('Background color 2', [0.95,0.95,1])
+    def sendStatusMessage(self, message):
+        msg = lcmrl.viewer_command_t()
+        msg.command_type = lcmrl.viewer_command_t.STATUS
+        msg.command_data = message
+        lcmUtils.publish('DRAKE_VIEWER_STATUS', msg)
 
-        # setup camera
-        applogic.setCameraTerrainModeEnabled(self.view, True)
-        applogic.resetCamera(viewDirection=[-1, 0, -0.3], view=self.view)
+    def onViewerDraw(self, msg):
 
-        # This setting improves the near plane clipping resolution.
-        # Drake often draws a very large ground plane which is detrimental to
-        # the near clipping for up close objects.  The trade-off is Z buffer
-        # resolution but in practice things look good with this setting.
-        self.view.renderer().SetNearClippingPlaneTolerance(0.0005)
+        for i in xrange(msg.num_links):
 
-        # add view behaviors
-        self.viewBehaviors = viewbehaviors.ViewBehaviors(self.view)
-        applogic._defaultRenderView = self.view
+            pos = msg.position[i]
+            quat = msg.quaternion[i]
+            robotNum = msg.robot_num[i]
+            linkName = msg.link_name[i]
 
-        self.mainWindow = QtGui.QMainWindow()
-        self.mainWindow.setCentralWidget(self.view)
-        self.mainWindow.resize(768 * (16/9.0), 768)
-        self.mainWindow.setWindowTitle('Drake Visualizer')
-        self.mainWindow.setWindowIcon(QtGui.QIcon(':/images/drake_logo.png'))
+            try:
+                link = self.getLink(robotNum, linkName)
+            except KeyError:
+                if linkName not in self.linkWarnings:
+                    print 'Error locating link name:', linkName
+                    self.linkWarnings.add(linkName)
+            else:
+                link.setTransform(pos, quat)
 
-        self.settings = QtCore.QSettings()
+        self.view.render()
 
-        self.fileMenu = self.mainWindow.menuBar().addMenu('&File')
-        self.viewMenu = self.mainWindow.menuBar().addMenu('&View')
-        self.viewMenuManager = PythonQt.dd.ddViewMenu(self.viewMenu)
+    def onPlanarLidar(self, msg, channel):
 
-        self.drakeVisualizer = DrakeVisualizer(self.view)
-        self.lcmglManager = lcmgl.LCMGLManager(self.view) if lcmgl.LCMGL_AVAILABLE else None
+        linkName = channel.replace('DRAKE_PLANAR_LIDAR_', '', 1)
+        robotNum, linkName = linkName.split('_', 1)
+        robotNum = int(robotNum)
 
-        model = om.getDefaultObjectModel()
-        model.getTreeWidget().setWindowTitle('Scene Browser')
-        model.getPropertiesPanel().setWindowTitle('Properties Panel')
+        try:
+            link = self.getLink(robotNum, linkName)
+        except KeyError:
+            if linkName not in self.linkWarnings:
+                print 'Error locating link name:', linkName
+                self.linkWarnings.add(linkName)
+        else:
+            if len(link.geometry):
+                polyData = link.geometry[0].polyDataItem
+            else:
+                polyData = vtk.vtkPolyData()
 
-        self.sceneBrowserDock = self.addWidgetToDock(model.getTreeWidget(), QtCore.Qt.LeftDockWidgetArea, visible=False)
-        self.propertiesDock = self.addWidgetToDock(self.wrapScrollArea(model.getPropertiesPanel()), QtCore.Qt.LeftDockWidgetArea, visible=False)
+                name = linkName + ' geometry data'
+                geom = type('', (), {})
+                geom.color = [1.0,0.0,0.0,1.0]
+                g = Geometry(name, geom, polyData, link.transform)
+                link.geometry.append(g)
 
-        self.addViewMenuSeparator()
+                linkFolder = self.getLinkFolder(robotNum, linkName)
+                self.addLinkGeometry(g, linkName, linkFolder)
+                g.polyDataItem.actor.SetUserTransform(link.transform)
 
-        self.screenGrabberPanel = ScreenGrabberPanel(self.view)
-        self.screenGrabberDock = self.addWidgetToDock(self.screenGrabberPanel.widget, QtCore.Qt.RightDockWidgetArea, visible=False)
+            points = vtk.vtkPoints()
+            verts = vtk.vtkCellArray()
 
-        self.cameraBookmarksPanel = camerabookmarks.CameraBookmarkWidget(self.view)
-        self.cameraBookmarksDock = self.addWidgetToDock(self.cameraBookmarksPanel.widget, QtCore.Qt.RightDockWidgetArea, visible=False)
+            t = msg.rad0
+            for r in msg.ranges:
+                if r >= 0:
+                    x = r * math.cos(t)
+                    y = r * math.sin(t)
 
-        self.cameraControlPanel = cameracontrolpanel.CameraControlPanel(self.view)
-        self.cameraControlDock = self.addWidgetToDock(self.cameraControlPanel.widget, QtCore.Qt.RightDockWidgetArea, visible=False)
+                    pointId = points.InsertNextPoint([x,y,0])
+                    verts.InsertNextCell(1)
+                    verts.InsertCellPoint(pointId)
 
-        act = self.fileMenu.addAction('&Quit')
-        act.setShortcut(QtGui.QKeySequence('Ctrl+Q'))
-        act.connect('triggered()', self.applicationInstance().quit)
+                t += msg.radstep
 
-        self.fileMenu.addSeparator()
-
-        act = self.fileMenu.addAction('&Open Data...')
-        act.setShortcut(QtGui.QKeySequence('Ctrl+O'))
-        act.connect('triggered()', self._onOpenDataFile)
-
-        applogic.addShortcut(self.mainWindow, 'F1', self._toggleObjectModel)
-        applogic.addShortcut(self.mainWindow, 'F8', applogic.showPythonConsole)
-        self.applicationInstance().connect('aboutToQuit()', self._onAboutToQuit)
-
-        for obj in om.getObjects():
-            obj.setProperty('Deletable', False)
-
-        self.mainWindow.show()
-        self._saveWindowState('MainWindowDefault')
-        self._restoreWindowState('MainWindowCustom')
-
-    def _onAboutToQuit(self):
-        self._saveWindowState('MainWindowCustom')
-        self.settings.sync()
-
-    def _restoreWindowState(self, key):
-        appsettings.restoreState(self.settings, self.mainWindow, key)
-
-    def _saveWindowState(self, key):
-        appsettings.saveState(self.settings, self.mainWindow, key)
-
-    def _toggleObjectModel(self):
-        self.sceneBrowserDock.setVisible(not self.sceneBrowserDock.visible)
-        self.propertiesDock.setVisible(not self.propertiesDock.visible)
-
-    def _toggleScreenGrabber(self):
-        self.screenGrabberDock.setVisible(not self.screenGrabberDock.visible)
-
-    def _toggleCameraBookmarks(self):
-        self.cameraBookmarksDock.setVisible(not self.cameraBookmarksDock.visible)
-
-    def _getOpenDataDirectory(self):
-        return self.settings.value('OpenDataDir') or os.path.expanduser('~')
-
-    def _storeOpenDataDirectory(self, filename):
-
-        if os.path.isfile(filename):
-            filename = os.path.dirname(filename)
-        if os.path.isdir(filename):
-            self.settings.setValue('OpenDataDir', filename)
+            polyData.SetPoints(points)
+            polyData.SetVerts(verts)
 
 
-    def _showErrorMessage(self, title, message):
-        QtGui.QMessageBox.warning(self.mainWindow, title, message)
+    def onPointCloud(self, msg, channel):
+        pointcloudName = channel.replace('DRAKE_POINTCLOUD_', '', 1)
 
+        polyData = vnp.numpyToPolyData(np.asarray(msg.points), createVertexCells=True)
 
-    def onOpenVrml(self, filename):
-        meshes, color = ioUtils.readVrml(filename)
-        folder = om.getOrCreateContainer(os.path.basename(filename), parentObj=om.getOrCreateContainer('files'))
-        for i, pair in enumerate(zip(meshes, color)):
-            mesh, color = pair
-            obj = vis.showPolyData(mesh, 'mesh %d' % i, color=color, parent=folder)
-            vis.addChildFrame(obj)
+        # If the user provided color channels, then use them to colorize
+        # the pointcloud.
+        channels = {msg.channel_names[i]: msg.channels[i] for i in range(msg.n_channels)}
+        if "r" in channels and "g" in channels and "b" in channels:
+            colorized = True
+            colorArray = np.empty((msg.n_points, 3), dtype=np.uint8)
+            for (colorIndex, color) in enumerate(["r", "g", "b"]):
+                colorArray[:, colorIndex] = 255 * np.asarray(channels[color])
+            vnp.addNumpyToVtk(polyData, colorArray, "rgb")
+        else:
+            colorized = False
 
-    def _openGeometry(self, filename):
+        folder = self.getPointCloudFolder()
 
-        if filename.lower().endswith('wrl'):
-            self.onOpenVrml(filename)
-            return
-
-        polyData = ioUtils.readPolyData(filename)
-
-        if not polyData or not polyData.GetNumberOfPoints():
-            self._showErrorMessage('Failed to read any data from file: %s' % filename, title='Reader error')
-            return
-
-        vis.showPolyData(polyData, os.path.basename(filename), parent='files')
-
-    def _onOpenDataFile(self):
-        fileFilters = "Data Files (*.obj *.ply *.stl *.vtk *.vtp *.wrl)";
-        filename = QtGui.QFileDialog.getOpenFileName(self.mainWindow, "Open...", self._getOpenDataDirectory(), fileFilters)
-        if not filename:
-            return
-
-        self._storeOpenDataDirectory(filename)
-        self._openGeometry(filename)
-
-    def wrapScrollArea(self, widget):
-        w = QtGui.QScrollArea()
-        w.setWidget(widget)
-        w.setWidgetResizable(True)
-        w.setWindowTitle(widget.windowTitle)
-        #w.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding)
-        return w
-
-    def addWidgetToViewMenu(self, widget):
-        self.viewMenuManager.addWidget(widget, widget.windowTitle)
-
-    def addViewMenuSeparator(self):
-        self.viewMenuManager.addSeparator()
-
-    def addWidgetToDock(self, widget, dockArea, visible=True):
-        dock = QtGui.QDockWidget()
-        dock.setWidget(widget)
-        dock.setWindowTitle(widget.windowTitle)
-        dock.setObjectName(widget.windowTitle + ' Dock')
-        dock.setVisible(visible)
-        self.mainWindow.addDockWidget(dockArea, dock)
-        self.addWidgetToViewMenu(dock)
-        return dock
-
-    def quit(self):
-        self.applicationInstance().quit()
-
-    def applicationInstance(self):
-        return QtCore.QCoreApplication.instance()
-
-    def start(self, globalsDict=None):
-        if globalsDict:
-            globalsDict['app'] = self
-            globalsDict['view'] = self.view
-            globalsDict['quit'] = self.quit
-            globalsDict['exit'] = self.quit
-
-        return QtCore.QCoreApplication.instance().exec_()
-
-
-def main(globalsDict=None):
-
-    app = DrakeVisualizerApp()
-    app.start(globalsDict)
-
-
-if __name__ == '__main__':
-    main(globals())
+        # If there was an existing point cloud by this name, then just
+        # set its polyData to the new point cloud.
+        # This has the effect of preserving all the user-specified properties
+        # like point size, coloration mode, alpha, etc.
+        previousPointcloud = folder.findChild(pointcloudName)
+        if previousPointcloud is not None:
+            previousPointcloud.setPolyData(polyData)
+            previousPointcloud._updateColorByProperty()
+        else:
+            item = vis.PolyDataItem(pointcloudName, polyData, view=None)
+            item.addToView(self.view)
+            if colorized:
+                item._updateColorByProperty()
+                item.setProperty("Color By", "rgb")
+            om.addToObjectModel(item, parentObj=folder)

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -293,7 +293,7 @@ class Geometry(object):
 
         geometry = []
         for polyData in polyDataList:
-            g = Geometry(geom, polyData)
+            g = Geometry(geom["name"], geom["parameters"], polyData)
             geometry.append(g)
         return geometry
 
@@ -310,15 +310,13 @@ class Geometry(object):
             colorArray = np.asarray(channels["rgb"]) * 255
             vnp.addNumpyToVtk(polyData, colorArray.astype(np.uint8), "rgb")
 
-    def __init__(self, geom, polyData):
-        params = geom["parameters"]
-        name = geom["name"]
+    def __init__(self, name, params, polyData):
         if "channels" in params:
             Geometry.addColorChannels(polyData, params["channels"])
         self.polyDataItem = vis.PolyDataItem(name, polyData, view=None)
         self.polyDataItem._updateColorByProperty()
 
-        color = geom.get("color", [1, 0, 0, 0.5])
+        color = params.get("color", [1, 0, 0, 0.5])
         self.polyDataItem.setProperty('Alpha', color[3])
         self.polyDataItem.actor.SetTexture(
             Geometry.TextureCache.get(
@@ -343,7 +341,7 @@ class DrakeVisualizer(object):
         self.subscribers = []
         self.view = view
         self.enable()
-        self.sendStatusMessage(0, ViewerStatus.OK, "ready")
+        self.sendStatusMessage(0, ViewerStatus.OK, {"ready": True})
 
     def _addSubscribers(self):
         self.subscribers.append(lcmUtils.addSubscriber(

--- a/src/python/director/drakevisualizer2.py
+++ b/src/python/director/drakevisualizer2.py
@@ -383,7 +383,6 @@ class DrakeVisualizer(object):
         msg.format_version_major = 1
         msg.format_version_minor = 0
         data = dict(timestamp=timestamp, **response.toJson())
-        print "responding:", data
         msg.data = json.dumps(data)
         msg.num_bytes = len(msg.data)
         lcmUtils.publish('DRAKE_VIEWER2_RESPONSE', msg)
@@ -424,13 +423,10 @@ class DrakeVisualizer(object):
             "missing_paths": []
         }
         for command in data["delete"]:
-            print "delete:", command["path"]
             result["deleted_paths"].append(self.handleDeletePath(command))
         for command in data["load"]:
-            print "load:", command["path"]
             result["added_geometries"].append(self.handleAddGeometry(command))
         for command in data["draw"]:
-            print "draw:", command["path"]
             path, missingGeometry = self.handleSetTransform(command)
             result["set_transforms"].append(path)
             if missingGeometry:

--- a/src/python/director/drakevisualizer2.py
+++ b/src/python/director/drakevisualizer2.py
@@ -1,0 +1,521 @@
+import math
+import os
+import json
+import numpy as np
+from collections import namedtuple
+from director import lcmUtils
+
+import director.objectmodel as om
+import director.applogic as app
+from director import transformUtils
+from director.debugVis import DebugData
+from director import ioUtils
+from director import filterUtils
+from director.shallowCopy import shallowCopy
+from director import vtkAll as vtk
+from director import vtkNumpy as vnp
+from director import visualization as vis
+from director import packagepath
+
+import bot_core as lcmbot
+
+# Currently, viewer lcm message types are in bot_core_lcmtypes and
+# robotlocomotion-lcmtypes, but drake only builds bot_core_lcmtypes.
+# When drake starts using robotlocomotion-lcmtypes, then the following
+# import can be used instead of getting viewer messages from bot_core_lcmtypes.
+#import robotlocomotion as lcmrl
+lcmrl = lcmbot
+
+from PythonQt import QtGui
+
+USE_TEXTURE_MESHES = True
+USE_SHADOWS = False
+
+
+class ViewerStatus:
+    OK = 0
+    MISSING_PATHS = 1
+    ERROR_UNKNOWN_FORMAT = -1
+    ERROR_UNKNOWN_FORMAT_VERSION = -2
+    ERROR_HANDLING_REQUEST = -3
+    ERROR_UKNOWN_REQUEST_TYPE = -4
+
+
+class ViewerResponse(namedtuple("ViewerResponse", ["status", "data"])):
+    def toJson(self):
+        return dict(status=self.status, **self.data)
+
+
+def transformFromDict(pose_data):
+    return transformUtils.transformFromPose(
+        pose_data.get("translation", [0, 0, 0]),
+        pose_data.get("quaternion", [1, 0, 0, 0]))
+
+
+class Geometry(object):
+    TextureCache = {}
+    PackageMap = None
+
+    @staticmethod
+    def createBox(params):
+        d = DebugData()
+        d.addCube(dimensions=params["lengths"], center=(0, 0, 0))
+        return [d.getPolyData()]
+
+    @staticmethod
+    def createSphere(params):
+        d = DebugData()
+        d.addSphere(center=(0, 0, 0), radius=params["radius"])
+        return [d.getPolyData()]
+
+    @staticmethod
+    def createCylinder(params):
+        d = DebugData()
+        d.addCylinder(center=(0, 0, 0),
+                      axis=(0, 0, 1),
+                      radius=params["radius"],
+                      length=params["length"])
+        return [d.getPolyData()]
+
+    @staticmethod
+    def createCapsule(params):
+        d = DebugData()
+        radius = params["radius"]
+        length = params["length"]
+        d.addCylinder(center=(0, 0, 0),
+                      axis=(0, 0, 1),
+                      radius=radius,
+                      length=length)
+        d.addSphere(center=(0, 0, length / 2.0), radius=radius)
+        d.addSphere(center=(0, 0, -length / 2.0), radius=radius)
+        return [d.getPolyData()]
+
+    @staticmethod
+    def createEllipsoid(params):
+        d = DebugData()
+        radii = params["radii"]
+        d.addEllipsoid(center=(0, 0, 0), radii=radii)
+        return [d.getPolyData()]
+
+    @staticmethod
+    def createMeshFromFile(params):
+        polyDataList = Geometry.loadPolyDataMeshes(params["filename"])
+        if "scale" in params:
+            polyDataList = Geometry.scaleGeometry(polyDataList,
+                                                  params["scale"])
+        return polyDataList
+
+    @staticmethod
+    def createMeshFromData(params):
+        verts = np.asarray(params["vertices"])
+        faces = np.asarray(params["faces"])
+        return [Geometry.createPolyDataFromMeshArrays(verts, faces)]
+
+    @staticmethod
+    def createPointcloud(params):
+        polyData = vnp.numpyToPolyData(np.asarray(params["points"]),
+                                       createVertexCells=True)
+        return [polyData]
+
+    @staticmethod
+    def createPlanarLidar(params):
+        ranges = np.asarray(params["ranges"])
+        angle_stop = (params["angle_start"] +
+                      len(ranges) * params["angle_step"])
+        angles = np.arange(
+            params["angle_start"],
+            angle_stop,
+            params["angle_step"])
+        x = ranges * np.cos(angles)
+        y = ranges * np.sin(angles)
+        z = np.zeros(x.shape)
+        points = np.vstack((x, y, z)).T
+        return [vnp.numpyToPolyData(points, createVertexCells=True)]
+
+    @staticmethod
+    def createPolyData(params):
+        if params["type"] == "box":
+            return Geometry.createBox(params)
+        elif params["type"] == "sphere":
+            return Geometry.createSphere(params)
+        elif params["type"] == "cylinder":
+            return Geometry.createCylinder(params)
+        elif params["type"] == "capsule":
+            return Geometry.createCapsule(params)
+        elif params["type"] == "ellipsoid":
+            return Geometry.createEllipsoid(params)
+        elif params["type"] == "mesh_file":
+            return Geometry.createMeshFromFile(params)
+        elif params["type"] == "mesh_data":
+            return Geometry.createMeshFromData(params)
+        elif params["type"] == "pointcloud":
+            return Geometry.createPointcloud(params)
+        elif params["type"] == "planar_lidar":
+            return Geometry.createPlanarLidar(params)
+        else:
+            raise Exception(
+                "Unsupported geometry type: {}".format(params["type"]))
+
+    @staticmethod
+    def createPolyDataFromMeshArrays(pts, faces):
+        pd = vtk.vtkPolyData()
+        pd.SetPoints(vtk.vtkPoints())
+        pd.GetPoints().SetData(vnp.getVtkFromNumpy(pts.copy()))
+
+        cells = vtk.vtkCellArray()
+        for face in faces:
+            assert len(face) == 3, "Non-triangular faces are not supported."
+            tri = vtk.vtkTriangle()
+            tri.GetPointIds().SetId(0, face[0])
+            tri.GetPointIds().SetId(1, face[1])
+            tri.GetPointIds().SetId(2, face[2])
+            cells.InsertNextCell(tri)
+
+        pd.SetPolys(cells)
+        return pd
+
+    @staticmethod
+    def scaleGeometry(polyDataList, scale):
+        if len(scale) == 1:
+            scale_x = scale_y = scale_z = scale
+        elif len(geom.float_data) == 3:
+            scale_x, scale_y, scale_z = scale
+
+        if scale_x != 1.0 or scale_y != 1.0 or scale_z != 1.0:
+            t = vtk.vtkTransform()
+            t.Scale(scale_x, scale_y, scale_z)
+            polyDataList = [filterUtils.transformPolyData(polyData, t) for polyData in polyDataList]
+
+        return polyDataList
+
+    @staticmethod
+    def computeNormals(polyDataList):
+
+        def addNormals(polyData):
+            hasNormals = polyData.GetPointData().GetNormals() is not None
+            return polyData if hasNormals else filterUtils.computeNormals(polyData)
+
+        return [addNormals(polyData) for polyData in polyDataList]
+
+
+    @staticmethod
+    def getTextureFileName(polyData):
+        textureArray = vtk.vtkStringArray.SafeDownCast(polyData.GetFieldData().GetAbstractArray('texture_filename'))
+        if not textureArray:
+            return None
+        return textureArray.GetValue(0)
+
+    @staticmethod
+    def loadTextureForMesh(polyData, meshFileName):
+
+        textureFileName = Geometry.getTextureFileName(polyData)
+        if textureFileName in Geometry.TextureCache or textureFileName is None:
+            return
+
+        if not os.path.isabs(textureFileName):
+            baseDir = os.path.dirname(meshFileName)
+            imageFile = os.path.join(baseDir, textureFileName)
+        else:
+            imageFile = textureFileName
+
+        if not os.path.isfile(imageFile):
+            print 'cannot find texture file:', textureFileName
+            return
+
+        image = ioUtils.readImage(imageFile)
+        if not image:
+            print 'failed to load image file:', imageFile
+            return
+
+        texture = vtk.vtkTexture()
+        texture.SetInput(image)
+        texture.EdgeClampOn()
+        texture.RepeatOn()
+
+        Geometry.TextureCache[textureFileName] = texture
+
+    @staticmethod
+    def resolvePackageFilename(filename):
+
+        if not packagepath.PackageMap.isPackageUrl(filename):
+            return filename
+
+        if Geometry.PackageMap is None:
+            import pydrake
+            m = packagepath.PackageMap()
+            m.populateFromSearchPaths([pydrake.getDrakePath()])
+            m.populateFromEnvironment(['DRAKE_PACKAGE_PATH', 'ROS_PACKAGE_PATH'])
+            Geometry.PackageMap = m
+
+        return Geometry.PackageMap.resolveFilename(filename) or filename
+
+    @staticmethod
+    def loadPolyDataMeshes(filename):
+
+        filename = Geometry.resolvePackageFilename(filename)
+        basename, ext = os.path.splitext(filename)
+
+        preferredExtensions = ['.vtm', '.vtp', '.obj']
+
+        for x in preferredExtensions:
+            if os.path.isfile(basename + x):
+                filename = basename + x
+                break
+
+        if not os.path.isfile(filename):
+            print 'warning, cannot find file:', filename
+            return []
+
+        if filename.endswith('vtm'):
+            polyDataList = ioUtils.readMultiBlock(filename)
+        else:
+            polyDataList = [ioUtils.readPolyData(filename)]
+
+        if USE_TEXTURE_MESHES:
+            for polyData in polyDataList:
+                Geometry.loadTextureForMesh(polyData, filename)
+
+        return polyDataList
+
+    @staticmethod
+    def createPolyDataForGeometry(geom):
+        polyDataList = Geometry.createPolyData(geom)
+        polyDataList = Geometry.computeNormals(polyDataList)
+        return polyDataList
+
+    @staticmethod
+    def createGeometry(geom):
+        polyDataList = Geometry.createPolyDataForGeometry(geom)
+
+        geometry = []
+        for polyData in polyDataList:
+            g = Geometry(geom, polyData)
+            geometry.append(g)
+        return geometry
+
+    @staticmethod
+    def addColorChannels(polyData, channels):
+        if "intensity" in channels:
+            colorBy = "intensity"
+            intensity = np.asarray(channels["intensity"]) * 255
+            vnp.addNumpyToVtk(polyData,
+                              intensity.astype(np.uint8),
+                              "intensity")
+        if "rgb" in channels:
+            colorBy = "rgb"  # default to rgb if provided
+            colorArray = np.asarray(channels["rgb"]) * 255
+            vnp.addNumpyToVtk(polyData, colorArray.astype(np.uint8), "rgb")
+
+    def __init__(self, geomData, polyData):
+        if "channels" in geomData:
+            Geometry.addColorChannels(polyData, geomData["channels"])
+        self.polyDataItem = vis.PolyDataItem("geometry", polyData, view=None)
+        self.polyDataItem._updateColorByProperty()
+
+        color = geomData.get("color", [1, 0, 0, 0.5])
+        self.polyDataItem.setProperty('Alpha', color[3])
+        self.polyDataItem.actor.SetTexture(
+            Geometry.TextureCache.get(
+                Geometry.getTextureFileName(polyData)))
+
+        if self.polyDataItem.actor.GetTexture():
+            self.polyDataItem.setProperty('Color',
+                                          QtGui.QColor(255, 255, 255))
+        else:
+            self.polyDataItem.setProperty(
+                'Color',
+                QtGui.QColor(*(255 * np.asarray(color[:3]))))
+
+        if USE_SHADOWS:
+            self.polyDataItem.shadowOn()
+
+
+def findPathToAncestor(fromItem, toItem):
+    path = [fromItem]
+    while fromItem is not toItem:
+        parent = fromItem.parent()
+        if parent is None:
+            raise ValueError(
+                "Cannot find a path from {} to {}".format(fromItem, toItem))
+        path.append(parent)
+        fromItem = parent
+    return path
+
+
+class DrakeVisualizer(object):
+    def __init__(self, view):
+
+        self.subscribers = []
+        self.view = view
+        self.enable()
+        self.sendStatusMessage(
+            0, ViewerResponse(ViewerStatus.OK, {"ready": True}))
+
+    def _addSubscribers(self):
+        self.subscribers.append(lcmUtils.addSubscriber(
+            'DRAKE_VIEWER2_REQUEST',
+            lcmrl.viewer2_comms_t,
+            self.onViewerRequest))
+
+    def _removeSubscribers(self):
+        for sub in self.subscribers:
+            lcmUtils.removeSubscriber(sub)
+        self.subscribers = []
+
+    def isEnabled(self):
+        return bool(self.subscribers)
+
+    def setEnabled(self, enabled):
+        if enabled and not self.isEnabled():
+            self._addSubscribers()
+        elif not enabled and self.isEnabled():
+            self._removeSubscribers()
+
+    def enable(self):
+        self.setEnabled(True)
+
+    def disable(self):
+        self.setEnabled(False)
+
+    def sendStatusMessage(self, timestamp, response):
+        msg = lcmrl.viewer2_comms_t()
+        msg.format = "viewer2_json"
+        msg.format_version_major = 1
+        msg.format_version_minor = 0
+        data = dict(timestamp=timestamp, **response.toJson())
+        print "responding:", data
+        msg.data = json.dumps(data)
+        msg.num_bytes = len(msg.data)
+        lcmUtils.publish('DRAKE_VIEWER2_RESPONSE', msg)
+
+    def decodeCommsMsg(self, msg):
+        if msg.format == "viewer2_json":
+            if msg.format_version_major == 1 and msg.format_version_minor == 0:
+                data = json.loads(msg.data)
+                return data, ViewerResponse(ViewerStatus.OK, {})
+            else:
+                return None, ViewerResponse(ViewerStatus.ERROR_UNKNOWN_FORMAT_VERSION,
+                                            {"supported_formats": {
+                                                 "viewer2_json": [{"major": 1,
+                                                                   "minor": 0}]
+                                            }})
+        else:
+            return None, ViewerResponse(ViewerStatus.ERROR_UNKNOWN_FORMAT,
+                                        {"supported_formats": {
+                                             "viewer2_json": [{"major": 1,
+                                                               "minor": 0}]
+                                        }})
+
+    def onViewerRequest(self, msg):
+        data, response = self.decodeCommsMsg(msg)
+        if data is None:
+            self.sendStatusMessage(msg.timestamp,
+                                   [responses])
+        else:
+            responses = self.handleViewerRequest(data)
+            self.sendStatusMessage(msg.timestamp,
+                                   responses)
+
+    def handleViewerRequest(self, data):
+        result = {
+            "deleted_paths": [],
+            "added_geometries": [],
+            "set_transforms": [],
+            "missing_paths": []
+        }
+        for command in data["delete"]:
+            print "delete:", command["path"]
+            result["deleted_paths"].append(self.handleDeletePath(command))
+        for command in data["load"]:
+            print "load:", command["path"]
+            result["added_geometries"].append(self.handleAddGeometry(command))
+        for command in data["draw"]:
+            print "draw:", command["path"]
+            path, missingGeometry = self.handleSetTransform(command)
+            result["set_transforms"].append(path)
+            if missingGeometry:
+                result["missing_paths"].append(path)
+        if not result["missing_paths"]:
+            return ViewerResponse(ViewerStatus.OK, result)
+        else:
+            return ViewerResponse(ViewerStatus.MISSING_PATHS, result)
+
+    def handleAddGeometry(self, command):
+        path = command["path"]
+        vtkGeoms = Geometry.createGeometry(command["geometry"])
+        return self.addGeometry(path, vtkGeoms)
+
+    def addGeometry(self, path, geomItems):
+        folder = self.getPathFolder(path)
+        ancestors = findPathToAncestor(folder, self.getRootFolder())
+        geomTransform = vtk.vtkTransform()
+        for item in reversed(ancestors):
+            if not hasattr(item, "transform"):
+                item.transform = vtk.vtkTransform()
+                item.transform.PostMultiply()
+            geomTransform.Concatenate(item.transform)
+
+        for geom in geomItems:
+            existing_item = self.getItemByPath(path + ["geometry"])
+            item = geom.polyDataItem
+            if existing_item is not None:
+                for prop in existing_item.propertyNames():
+                    item.setProperty(prop, existing_item.getProperty(prop))
+                om.removeFromObjectModel(existing_item)
+            else:
+                item.setProperty("Point Size", 2)
+                for colorBy in ["rgb", "intensity"]:
+                    try:
+                        item.setProperty("Color By", colorBy)
+                    except ValueError:
+                        pass
+                    else:
+                        break
+
+            item.addToView(self.view)
+            om.addToObjectModel(item, parentObj=folder)
+            item.actor.SetUserTransform(geomTransform)
+
+        return path
+
+    def getPathForItem(self, item):
+        return [x.getProperty("Name") for x in reversed(findPathToAncestor(
+            item, self.getRootFolder())[:-1])]
+
+    def handleSetTransform(self, command):
+        return self._setTransform(command["path"],
+                                  transformFromDict(command["transform"]))
+
+    def _setTransform(self, path, transform):
+        folder = self.getPathFolder(path)
+        if not hasattr(folder, "transform"):
+            folder.transform = transform
+        else:
+            folder.transform.SetMatrix(transform.GetMatrix())
+        self.view.render()
+        return path, len(folder.children()) == 0
+
+    def handleDeletePath(self, command):
+        path = command["path"]
+        item = self.getItemByPath(path)
+        if item is not None:
+            om.removeFromObjectModel(item)
+        return path
+
+    def getRootFolder(self):
+        return om.getOrCreateContainer('drake viewer',
+                                       parentObj=om.findObjectByName('scene'))
+
+    def getItemByPath(self, path):
+        item = self.getRootFolder()
+        for element in path:
+            item = item.findChild(element)
+            if item is None:
+                return None
+        return item
+
+    def getPathFolder(self, path):
+        folder = self.getRootFolder()
+        for element in path:
+            folder = om.getOrCreateContainer(element, parentObj=folder)
+        return folder

--- a/src/python/director/drakevisualizerapp.py
+++ b/src/python/director/drakevisualizerapp.py
@@ -1,0 +1,209 @@
+##########################################################
+from director.screengrabberpanel import ScreenGrabberPanel
+from director import lcmgl
+from director import objectmodel as om
+from director import applogic
+from director import appsettings
+from director import viewbehaviors
+from director import camerabookmarks
+from director import cameracontrolpanel
+from director import visualization as vis
+from director import ioUtils
+import PythonQt
+from PythonQt import QtCore, QtGui
+
+
+class DrakeVisualizerApp():
+
+    def __init__(self, visualizerClass):
+
+        self.applicationInstance().setOrganizationName('RobotLocomotionGroup')
+        self.applicationInstance().setApplicationName('drake-visualizer')
+
+        om.init()
+        self.view = PythonQt.dd.ddQVTKWidgetView()
+
+        # init grid
+        self.gridObj = vis.showGrid(self.view, parent='scene')
+        self.gridObj.setProperty('Surface Mode', 'Surface with edges')
+        self.gridObj.setProperty('Color', [0,0,0])
+        self.gridObj.setProperty('Alpha', 0.1)
+
+        # init view options
+        self.viewOptions = vis.ViewOptionsItem(self.view)
+        om.addToObjectModel(self.viewOptions, parentObj=om.findObjectByName('scene'))
+        self.viewOptions.setProperty('Background color', [0.3, 0.3, 0.35])
+        self.viewOptions.setProperty('Background color 2', [0.95,0.95,1])
+
+        # setup camera
+        applogic.setCameraTerrainModeEnabled(self.view, True)
+        applogic.resetCamera(viewDirection=[-1, 0, -0.3], view=self.view)
+
+        # This setting improves the near plane clipping resolution.
+        # Drake often draws a very large ground plane which is detrimental to
+        # the near clipping for up close objects.  The trade-off is Z buffer
+        # resolution but in practice things look good with this setting.
+        self.view.renderer().SetNearClippingPlaneTolerance(0.0005)
+
+        # add view behaviors
+        self.viewBehaviors = viewbehaviors.ViewBehaviors(self.view)
+        applogic._defaultRenderView = self.view
+
+        self.mainWindow = QtGui.QMainWindow()
+        self.mainWindow.setCentralWidget(self.view)
+        self.mainWindow.resize(768 * (16/9.0), 768)
+        self.mainWindow.setWindowTitle('Drake Visualizer')
+        self.mainWindow.setWindowIcon(QtGui.QIcon(':/images/drake_logo.png'))
+
+        self.settings = QtCore.QSettings()
+
+        self.fileMenu = self.mainWindow.menuBar().addMenu('&File')
+        self.viewMenu = self.mainWindow.menuBar().addMenu('&View')
+        self.viewMenuManager = PythonQt.dd.ddViewMenu(self.viewMenu)
+
+        self.drakeVisualizer = visualizerClass(self.view)
+        self.lcmglManager = lcmgl.LCMGLManager(self.view) if lcmgl.LCMGL_AVAILABLE else None
+
+        model = om.getDefaultObjectModel()
+        model.getTreeWidget().setWindowTitle('Scene Browser')
+        model.getPropertiesPanel().setWindowTitle('Properties Panel')
+
+        self.sceneBrowserDock = self.addWidgetToDock(model.getTreeWidget(), QtCore.Qt.LeftDockWidgetArea, visible=False)
+        self.propertiesDock = self.addWidgetToDock(self.wrapScrollArea(model.getPropertiesPanel()), QtCore.Qt.LeftDockWidgetArea, visible=False)
+
+        self.addViewMenuSeparator()
+
+        self.screenGrabberPanel = ScreenGrabberPanel(self.view)
+        self.screenGrabberDock = self.addWidgetToDock(self.screenGrabberPanel.widget, QtCore.Qt.RightDockWidgetArea, visible=False)
+
+        self.cameraBookmarksPanel = camerabookmarks.CameraBookmarkWidget(self.view)
+        self.cameraBookmarksDock = self.addWidgetToDock(self.cameraBookmarksPanel.widget, QtCore.Qt.RightDockWidgetArea, visible=False)
+
+        self.cameraControlPanel = cameracontrolpanel.CameraControlPanel(self.view)
+        self.cameraControlDock = self.addWidgetToDock(self.cameraControlPanel.widget, QtCore.Qt.RightDockWidgetArea, visible=False)
+
+        act = self.fileMenu.addAction('&Quit')
+        act.setShortcut(QtGui.QKeySequence('Ctrl+Q'))
+        act.connect('triggered()', self.applicationInstance().quit)
+
+        self.fileMenu.addSeparator()
+
+        act = self.fileMenu.addAction('&Open Data...')
+        act.setShortcut(QtGui.QKeySequence('Ctrl+O'))
+        act.connect('triggered()', self._onOpenDataFile)
+
+        applogic.addShortcut(self.mainWindow, 'F1', self._toggleObjectModel)
+        applogic.addShortcut(self.mainWindow, 'F8', applogic.showPythonConsole)
+        self.applicationInstance().connect('aboutToQuit()', self._onAboutToQuit)
+
+        for obj in om.getObjects():
+            obj.setProperty('Deletable', False)
+
+        self.mainWindow.show()
+        self._saveWindowState('MainWindowDefault')
+        self._restoreWindowState('MainWindowCustom')
+
+    def _onAboutToQuit(self):
+        self._saveWindowState('MainWindowCustom')
+        self.settings.sync()
+
+    def _restoreWindowState(self, key):
+        appsettings.restoreState(self.settings, self.mainWindow, key)
+
+    def _saveWindowState(self, key):
+        appsettings.saveState(self.settings, self.mainWindow, key)
+
+    def _toggleObjectModel(self):
+        self.sceneBrowserDock.setVisible(not self.sceneBrowserDock.visible)
+        self.propertiesDock.setVisible(not self.propertiesDock.visible)
+
+    def _toggleScreenGrabber(self):
+        self.screenGrabberDock.setVisible(not self.screenGrabberDock.visible)
+
+    def _toggleCameraBookmarks(self):
+        self.cameraBookmarksDock.setVisible(not self.cameraBookmarksDock.visible)
+
+    def _getOpenDataDirectory(self):
+        return self.settings.value('OpenDataDir') or os.path.expanduser('~')
+
+    def _storeOpenDataDirectory(self, filename):
+
+        if os.path.isfile(filename):
+            filename = os.path.dirname(filename)
+        if os.path.isdir(filename):
+            self.settings.setValue('OpenDataDir', filename)
+
+
+    def _showErrorMessage(self, title, message):
+        QtGui.QMessageBox.warning(self.mainWindow, title, message)
+
+
+    def onOpenVrml(self, filename):
+        meshes, color = ioUtils.readVrml(filename)
+        folder = om.getOrCreateContainer(os.path.basename(filename), parentObj=om.getOrCreateContainer('files'))
+        for i, pair in enumerate(zip(meshes, color)):
+            mesh, color = pair
+            obj = vis.showPolyData(mesh, 'mesh %d' % i, color=color, parent=folder)
+            vis.addChildFrame(obj)
+
+    def _openGeometry(self, filename):
+
+        if filename.lower().endswith('wrl'):
+            self.onOpenVrml(filename)
+            return
+
+        polyData = ioUtils.readPolyData(filename)
+
+        if not polyData or not polyData.GetNumberOfPoints():
+            self._showErrorMessage('Failed to read any data from file: %s' % filename, title='Reader error')
+            return
+
+        vis.showPolyData(polyData, os.path.basename(filename), parent='files')
+
+    def _onOpenDataFile(self):
+        fileFilters = "Data Files (*.obj *.ply *.stl *.vtk *.vtp *.wrl)";
+        filename = QtGui.QFileDialog.getOpenFileName(self.mainWindow, "Open...", self._getOpenDataDirectory(), fileFilters)
+        if not filename:
+            return
+
+        self._storeOpenDataDirectory(filename)
+        self._openGeometry(filename)
+
+    def wrapScrollArea(self, widget):
+        w = QtGui.QScrollArea()
+        w.setWidget(widget)
+        w.setWidgetResizable(True)
+        w.setWindowTitle(widget.windowTitle)
+        #w.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding)
+        return w
+
+    def addWidgetToViewMenu(self, widget):
+        self.viewMenuManager.addWidget(widget, widget.windowTitle)
+
+    def addViewMenuSeparator(self):
+        self.viewMenuManager.addSeparator()
+
+    def addWidgetToDock(self, widget, dockArea, visible=True):
+        dock = QtGui.QDockWidget()
+        dock.setWidget(widget)
+        dock.setWindowTitle(widget.windowTitle)
+        dock.setObjectName(widget.windowTitle + ' Dock')
+        dock.setVisible(visible)
+        self.mainWindow.addDockWidget(dockArea, dock)
+        self.addWidgetToViewMenu(dock)
+        return dock
+
+    def quit(self):
+        self.applicationInstance().quit()
+
+    def applicationInstance(self):
+        return QtCore.QCoreApplication.instance()
+
+    def start(self, globalsDict=None):
+        if globalsDict:
+            globalsDict['app'] = self
+            globalsDict['view'] = self.view
+            globalsDict['quit'] = self.quit
+            globalsDict['exit'] = self.quit
+
+        return QtCore.QCoreApplication.instance().exec_()

--- a/src/python/director/drakevisualizerapp1.py
+++ b/src/python/director/drakevisualizerapp1.py
@@ -1,0 +1,11 @@
+from director import drakevisualizer
+from director.drakevisualizerapp import DrakeVisualizerApp
+
+
+def main(globalsDict=None):
+    app = DrakeVisualizerApp(drakevisualizer.DrakeVisualizer)
+    app.start(globalsDict)
+
+
+if __name__ == '__main__':
+    main(globals())

--- a/src/python/director/drakevisualizerapp2.py
+++ b/src/python/director/drakevisualizerapp2.py
@@ -1,0 +1,11 @@
+from director import drakevisualizer2
+from director.drakevisualizerapp import DrakeVisualizerApp
+
+
+def main(globalsDict=None):
+    app = DrakeVisualizerApp(drakevisualizer2.DrakeVisualizer)
+    app.start(globalsDict)
+
+
+if __name__ == '__main__':
+    main(globals())

--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(python_tests_core
 set(python_tests_lcm
   testDrakeVisualizer.py
   testDrakeVisualizerInterface.py
+  testDrakeVisualizer2Interface.py
 )
 
 set(python_tests_robot

--- a/src/python/tests/testDrakeVisualizer2Interface.py
+++ b/src/python/tests/testDrakeVisualizer2Interface.py
@@ -4,8 +4,6 @@ import time
 import math
 import sys
 import numpy as np
-sys.path.append("build/install/lib/python2.7/site-packages")
-
 import lcm
 import bot_core
 
@@ -122,30 +120,22 @@ if __name__ == '__main__':
     vis.draw("robot1/link1/box2", {"translation": [1, 0, 0], "quaternion": [1, 0, 0, 0]})
     vis.draw("robot1/link1/points", {"translation": [0, 1, 0], "quaternion": [1, 0, 0, 0]})
     vis.draw("robot1/link1/planar lidar", {"translation": [0, 2, 0], "quaternion": [1, 0, 0, 0]})
-    try:
-        while True:
-            for i in range(1000):
-                x1 = math.sin(math.pi * 2 * i / 1000.0)
-                pose = {
-                    "translation": [x1, 0, 0],
-                    "quaternion": [1, 0, 0, 0]
-                }
-                vis.draw("robot1/link1", pose)
+    for j in range(2):
+        for i in range(1000):
+            x1 = math.sin(math.pi * 2 * i / 1000.0)
+            pose = {
+                "translation": [x1, 0, 0],
+                "quaternion": [1, 0, 0, 0]
+            }
+            vis.draw("robot1/link1", pose)
 
-                x2 = math.sin(math.pi * 2 * i / 500.0)
-                pose = {
-                    "translation": [x2, 0, 0],
-                    "quaternion": [1, 0, 0, 0]
-                }
-                vis.draw("robot1/link1/box1", pose)
+            x2 = math.sin(math.pi * 2 * i / 500.0)
+            pose = {
+                "translation": [x2, 0, 0],
+                "quaternion": [1, 0, 0, 0]
+            }
+            vis.draw("robot1/link1/box1", pose)
 
-                vis.publish()
-                time.sleep(0.001)
-    except:
-        # print "deleting"
-        # paths = vis.geometries.keys()
-        # for path in paths:
-        #     vis.delete(path)
-        # vis.publish()
-        raise
+            vis.publish()
+            time.sleep(0.001)
 


### PR DESCRIPTION
@patmarion this will probably need some work before it's ready to merge, but I wanted to get started on the PR now. 

This implements the interface described in #415 (closes #415)

I've split the old `drakevisualizer.py` into `drakevisualizer.py` and `drakevisualizerapp.py`. I've also created the new interface in `drakevisualizer2.py`. Additionally, I've created `drakevisualizerapp1.py` and `drakevisualizerapp2.py` which import the relevant modules to construct the v1 and v2 apps. And I've added a command line flag to `drakeVisualizerApp.cpp`

@patmarion I have no attachment to any of those naming choices. They're just the first thing I tried that managed to cleanly separate all the old and new functionality. Feel free to rearrange and rename them as you see fit. Everything I've added is contained in `drakevisualizer2.py` and the new `testDrakeVisualizer2Interface.py`; all the other changes are just rearrangements of existing code. 