### PR TITLE
Updated ddDrakeModel.cpp to use RigidBodyTree's new API where the model instance ID set needs to be explicitly specified.

### DIFF
--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -961,7 +961,8 @@ QVector<double> ddDrakeModel::getCenterOfMass() const
 {
   URDFRigidBodyTreeVTK::Ptr model = this->Internal->Model;
   Vector3d com;
-  com = model->centerOfMass<double>(*model->cache);
+  com = model->centerOfMass<double>(*model->cache,
+                                    {0} /* model instance ID set */);
 
   QVector<double> ret;
   ret << com[0] << com[1] << com[2];


### PR DESCRIPTION
This needs to go in alongside https://github.com/RobotLocomotion/drake/pull/4706.