### PR TITLE
Added option to keep arm pose when planning nominal pose

### DIFF
--- a/src/python/director/ikplanner.py
+++ b/src/python/director/ikplanner.py
@@ -863,7 +863,7 @@ class IKPlanner(object):
         return self.computePostureGoal(startPose, endPose)
 
 
-    def computeHomeNominalPose(self, startPose, footReferenceFrame, pelvisHeightAboveFeet=1.0167, ikParameters=None):
+    def computeHomeNominalPose(self, startPose, footReferenceFrame, pelvisHeightAboveFeet=1.0167, ikParameters=None, moveArms=True):
         ''' Compute a pose with the pelvis above the mid point of the feet with zero roll and pitch.
             The back and neck joints are also zeroed. Don't move the arm joints.
             The default height is Valkyrie specific
@@ -887,8 +887,12 @@ class IKPlanner(object):
         q.tspan = [1.0, 1.0]
         constraints.extend([p, q])
 
-        constraints.append(self.createLockedLeftArmPostureConstraint(nominalPoseName))
-        constraints.append(self.createLockedRightArmPostureConstraint(nominalPoseName))
+        if moveArms:
+            constraints.append(self.createLockedLeftArmPostureConstraint(nominalPoseName))
+            constraints.append(self.createLockedRightArmPostureConstraint(nominalPoseName))
+        else:
+            constraints.append(self.createLockedLeftArmPostureConstraint(startPoseName))
+            constraints.append(self.createLockedRightArmPostureConstraint(startPoseName))
         constraints.append( self.createPostureConstraint('q_zero', self.neckJoints) )
 
         constraintSet = ConstraintSet(self, constraints, '', startPoseName)
@@ -897,9 +901,9 @@ class IKPlanner(object):
         return endPose, info
 
 
-    def computeHomeNominalPlan(self, startPose, footReferenceFrame, pelvisHeightAboveFeet=1.0167):
+    def computeHomeNominalPlan(self, startPose, footReferenceFrame, pelvisHeightAboveFeet=1.0167, moveArms=True):
 
-        endPose, info = self.computeHomeNominalPose(startPose, footReferenceFrame, pelvisHeightAboveFeet)
+        endPose, info = self.computeHomeNominalPose(startPose, footReferenceFrame, pelvisHeightAboveFeet, None, moveArms)
         print 'info:', info
 
         return self.computePostureGoal(startPose, endPose)


### PR DESCRIPTION
Added an option to compute home nominal plans without moving the arms.
Such function used to exist in the past.

Fixed indentation and spaces.


