### PR TITLE
Minor

### DIFF
--- a/src/app/ddPointCloudLCM.cpp
+++ b/src/app/ddPointCloudLCM.cpp
@@ -265,6 +265,19 @@ QStringList ddPointCloudLCM::getLidarNames() const {
 }
 
 //-----------------------------------------------------------------------------
+QString ddPointCloudLCM::getLidarChannelName(const QString& lidarName) {
+  QString key = QString("planar_lidars.") + lidarName + QString(".lcm_channel");
+
+  char* channelName;
+  if (!bot_param_get_str(mBotParam, key.toAscii().data(), &channelName) == 0){
+    printf("Could not find lcm_channel property of %s\n", lidarName.toAscii().data());
+    return 0;
+  }
+
+  return QString(channelName);
+}
+
+//-----------------------------------------------------------------------------
 QString ddPointCloudLCM::getLidarFriendlyName(const QString& lidarName) {
   QString key = QString("planar_lidars.") + lidarName + QString(".sensor_name");
 
@@ -275,6 +288,19 @@ QString ddPointCloudLCM::getLidarFriendlyName(const QString& lidarName) {
   }
 
   return QString(friendlyName);
+}
+
+//-----------------------------------------------------------------------------
+QString ddPointCloudLCM::getLidarCoordinateFrame(const QString& lidarName) {
+  QString key = QString("planar_lidars.") + lidarName + QString(".coord_frame");
+
+  char* coordFrame;
+  if (!bot_param_get_str(mBotParam, key.toAscii().data(), &coordFrame) == 0){
+    printf("Could not find coord_frame property of %s\n", lidarName.toAscii().data());
+    return 0;
+  }
+
+  return QString(coordFrame);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/app/ddPointCloudLCM.h
+++ b/src/app/ddPointCloudLCM.h
@@ -39,6 +39,8 @@ public:
   int getLidarFrequency(const QString& lidarName);
   bool displayLidar(const QString& lidarName);
   QList<int> getLidarIntensity(const QString& lidarName);
+  QString getLidarChannelName(const QString& lidarName);
+  QString getLidarCoordinateFrame(const QString& lidarName);
 
 protected slots:
 

--- a/src/app/wrapped_methods_drc.txt
+++ b/src/app/wrapped_methods_drc.txt
@@ -26,6 +26,8 @@ void ddPointCloudLCM::init(ddLCMThread*, const QString&);
 qint64 ddPointCloudLCM::getPointCloudFromPointCloud(vtkPolyData*);
 QStringList ddPointCloudLCM::getLidarNames() const;
 QString ddPointCloudLCM::getLidarFriendlyName(const QString&);
+QString ddPointCloudLCM::getLidarChannelName(const QString&);
+QString ddPointCloudLCM::getLidarCoordinateFrame(const QString&);
 int ddPointCloudLCM::getLidarFrequency(const QString&);
 bool ddPointCloudLCM::displayLidar(const QString&);
 QList<int> ddPointCloudLCM::getLidarIntensity(const QString&);

--- a/src/python/director/perception.py
+++ b/src/python/director/perception.py
@@ -484,7 +484,7 @@ class MultiSenseSource(TimerCallback):
 
 class LidarSource(TimerCallback):
 
-    def __init__(self, view, channelName, sensorName, intensityRange):
+    def __init__(self, view, channelName, coordinateFrame, sensorName, intensityRange):
         TimerCallback.__init__(self)
         self.view = view
         self.channelName = channelName
@@ -500,6 +500,7 @@ class LidarSource(TimerCallback):
         self.colorBy = 'Solid Color'
         self.initScanLines()
         self.sensorName = sensorName
+        self.coordinateFrame = coordinateFrame
 
         self.revPolyData = vtk.vtkPolyData()
         self.polyDataObj = vis.PolyDataItem('Lidar Sweep', self.revPolyData, view)
@@ -560,6 +561,7 @@ class LidarSource(TimerCallback):
         if self.reader is None:
             self.reader = drc.vtkLidarSource()
             self.reader.subscribe(self.channelName)
+            self.reader.setCoordinateFrame(self.coordinateFrame)
             self.reader.InitBotConfig(drcargs.args().config_file)
             self.reader.SetDistanceRange(0.25, 80.0)
             self.reader.SetHeightRange(-80.0, 80.0)
@@ -837,7 +839,7 @@ def init(view):
     for lidar in lidarNames:
         if queue.displayLidar(lidar):
             
-            l = LidarSource(view, lidar, queue.getLidarFriendlyName(lidar), queue.getLidarIntensity(lidar))
+            l = LidarSource(view, queue.getLidarChannelName(lidar), queue.getLidarCoordinateFrame(lidar), queue.getLidarFriendlyName(lidar), queue.getLidarIntensity(lidar))
             l.start()
             lidarDriver = l
             _lidarItem = LidarItem(l)

--- a/src/vtk/DRCFilters/vtkLidarSource.cxx
+++ b/src/vtk/DRCFilters/vtkLidarSource.cxx
@@ -158,6 +158,8 @@ public:
     // Used to filter out range returns which are oblique to lidar sensor
     this->EdgeAngleThreshold = 0;  // degrees, 30 was  default
     this->channelName = ""; // none set, no subscription made
+    this->coordinateFrame = ""; // none set, no transform made
+
 
     this->HeightRange[0] = -80.0;
     this->HeightRange[1] = 80.0;
@@ -167,6 +169,11 @@ public:
     {
       std::cerr <<"ERROR: lcm is not good()" <<std::endl;
     }
+  }
+
+  void setCoordinateFrame(std::string coordinateFrame)
+  {
+    this->coordinateFrame = coordinateFrame;
   }
 
   void subscribe(std::string channelName)
@@ -485,8 +492,8 @@ protected:
 
 
     // Assumes frame is same as channel name. TODO: look up channel from botconfig
-    get_trans_with_utime(this->channelName, "local", msg->utime, scanToLocalStart);
-    get_trans_with_utime(this->channelName, "local", msg->utime +  1e6*3/(40*4), scanToLocalEnd);
+    get_trans_with_utime(this->coordinateFrame, "local", msg->utime, scanToLocalStart);
+    get_trans_with_utime(this->coordinateFrame, "local", msg->utime +  1e6*3/(40*4), scanToLocalEnd);
     
     get_trans_with_utime("body", "local", msg->utime, bodyToLocalStart);
 
@@ -535,6 +542,7 @@ protected:
   }
 
   std::string channelName;
+  std::string coordinateFrame;
   bool NewData;
   bool ShouldStop;
   int MaxNumberOfScanLines;
@@ -641,6 +649,12 @@ void vtkLidarSource::Poll()
 void vtkLidarSource::subscribe(const char* channelName)
 {
   this->Internal->Listener->subscribe(channelName);
+}
+
+//-----------------------------------------------------------------------------
+void vtkLidarSource::setCoordinateFrame(const char* coordinateFrame)
+{
+  this->Internal->Listener->setCoordinateFrame(coordinateFrame);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/vtk/DRCFilters/vtkLidarSource.h
+++ b/src/vtk/DRCFilters/vtkLidarSource.h
@@ -59,6 +59,8 @@ public:
 
   void subscribe(const char* channelName);
 
+  void setCoordinateFrame(const char* coordinateFrame);
+
   void InitBotConfig(const char* filename);
 
   void GetTransform(const char* fromFrame, const char* toFrame, vtkIdType utime, vtkTransform* transform);


### PR DESCRIPTION
@patmarion The coordinate frame in vtkLidarSource is assumed to be the lidar name. Similarly for the channel name. This fixes it.