### PR TITLE
Disable parallel XVFB tests

### DIFF
--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -88,6 +88,10 @@ macro(add_python_test name label)
   add_test(${test_name} ${wrap_vfb} ${python_exe} ${CMAKE_CURRENT_SOURCE_DIR}/${name} ${python_test_args} ${${base_name}_extra_args})
   set_property(TEST ${test_name} PROPERTY ENVIRONMENT ${python_coverage_environment_arg})
   set_property(TEST ${test_name} PROPERTY LABELS ${label})
+  if(wrap_vfb)
+    # xvfb-run can fail to bind a display address when run in parallel
+    set_property(TEST ${test_name} PROPERTY RESOURCE_LOCK xvfb)
+  endif()
 
   # Check whether additional test cases have been defined
   set(n 2)
@@ -96,6 +100,10 @@ macro(add_python_test name label)
     add_test(${test_name} ${wrap_vfb} ${python_exe} ${CMAKE_CURRENT_SOURCE_DIR}/${name} ${python_test_args} ${${base_name}_extra_args_${n}})
     set_property(TEST ${test_name} PROPERTY ENVIRONMENT ${python_coverage_environment_arg})
     set_property(TEST ${test_name} PROPERTY LABELS ${label})
+    if(wrap_vfb)
+      # xvfb-run can fail to bind a display address when run in parallel
+      set_property(TEST ${test_name} PROPERTY RESOURCE_LOCK xvfb)
+    endif()
     math(EXPR n "${n}+1")
   endwhile()
 endmacro()


### PR DESCRIPTION
Mark tests using `xvfb-run` as depending on a shared resource. This will prevent trying to create many VFB's in parallel, which can result in `xvfb-run` being unable to allocate a display.