### PR TITLE
Add color to SDF Sceneloader

### DIFF
--- a/src/python/director/sceneloader.py
+++ b/src/python/director/sceneloader.py
@@ -35,7 +35,8 @@ class SceneLoader(object):
                 t.PreMultiply()
                 t.Concatenate(t3)
                 p = transformUtils.poseFromTransform(t)
-                name = model.name;
+                name = model.name
+                color = col.color[0:3] if col.color is not None else [0.8,0.8,0.8]
                 if len(link.name)>0 and link.name != model.name:
                     name+='-'+link.name
                 if len(col.name)>0 and len(link.collisions)>1:
@@ -51,10 +52,10 @@ class SceneLoader(object):
                 if col.geometry_type=='sphere':
                     print 'Sphere geometry is unsupported - SKIPPING!'
                 if col.geometry_type=='box':
-                    desc = dict(classname='BoxAffordanceItem', Name=name, uuid=newUUID(), pose=p, Color=[0.8, 0.8, 0.8], Dimensions=map(float, col.geometry_data['size'].split(' ')))
+                    desc = dict(classname='BoxAffordanceItem', Name=name, uuid=newUUID(), pose=p, Color=color, Dimensions=map(float, col.geometry_data['size'].split(' ')))
                     self.affordanceManager.newAffordanceFromDescription(desc)
                 if col.geometry_type=='cylinder':
-                    desc = dict(classname='CylinderAffordanceItem', Name=name, uuid=newUUID(), pose=p, Color=[0.8, 0.8, 0.8], Radius=float(col.geometry_data['radius']), Length = float(col.geometry_data['length']))
+                    desc = dict(classname='CylinderAffordanceItem', Name=name, uuid=newUUID(), pose=p, Color=color, Radius=float(col.geometry_data['radius']), Length = float(col.geometry_data['length']))
                     self.affordanceManager.newAffordanceFromDescription(desc)
     
     def generateBoxLinkNode(self, aff):

--- a/src/python/director/thirdparty/pysdf.py
+++ b/src/python/director/thirdparty/pysdf.py
@@ -735,6 +735,7 @@ class LinkPart(SpatialEntity):
     self.geometry_type = None
     self.geometry_data = {}
     self.gtypes = 'box', 'cylinder', 'sphere', 'mesh'
+    self.color = [ 0.8, 0.8, 0.8, 1 ]  # RGBA
     if 'tree' in kwargs:
       self.from_tree(kwargs['tree'])
 
@@ -749,6 +750,15 @@ class LinkPart(SpatialEntity):
     gnode = get_node(node, 'geometry')
     if gnode == None:
       return
+    material = get_node(node, 'material')
+    if material is not None:
+      color_node = get_node(material, 'color')
+      if color_node is not None:
+        try:
+          color = color_node.attrib['rgba'].split(' ')
+          self.color = [ float(e) for e in color ]
+        except:
+          pass
     for gtype in self.gtypes:
       typenode = get_node(gnode, gtype)
       if typenode != None:


### PR DESCRIPTION
This PR adds parsing of color to pysdf and consequently to sceneloader, i.e. loaded SDF worlds aren't limited to grey boxes anymore.

The only supported version is by adding a material tag with a RGBA color. The alpha channel is not used though:
```xml
<material name="blue">
    <color rgba="0 0 .8 1" />
</material>
```