### PR TITLE
rename drakevisualizer2 to treeviewer

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -33,7 +33,6 @@ set(python_files
   director/depthscanner.py
   director/doordemo.py
   director/drakevisualizer.py
-  director/drakevisualizer2.py
   director/drakevisualizerapp.py
   director/drcargs.py
   director/drilldemo.py
@@ -125,6 +124,7 @@ set(python_files
   director/timercallback.py
   director/transformUtils.py
   director/trackers.py
+  director/treeviewer.py
   director/utime.py
   director/uuidutil.py
   director/valvedemo.py

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -292,6 +292,7 @@ class Link(object):
 
 
 class DrakeVisualizer(object):
+    name = "drake viewer"
 
     def __init__(self, view):
 
@@ -342,7 +343,7 @@ class DrakeVisualizer(object):
         self.sendStatusMessage('successfully added robot')
 
     def getRootFolder(self):
-        return om.getOrCreateContainer('drake viewer', parentObj=om.findObjectByName('scene'))
+        return om.getOrCreateContainer(self.name, parentObj=om.findObjectByName('scene'))
 
     def getRobotFolder(self, robotNum):
         return om.getOrCreateContainer('robot %d' % robotNum, parentObj=self.getRootFolder())

--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -292,7 +292,7 @@ class Link(object):
 
 
 class DrakeVisualizer(object):
-    name = "drake viewer"
+    name = 'Drake Visualizer'
 
     def __init__(self, view):
 
@@ -343,7 +343,7 @@ class DrakeVisualizer(object):
         self.sendStatusMessage('successfully added robot')
 
     def getRootFolder(self):
-        return om.getOrCreateContainer(self.name, parentObj=om.findObjectByName('scene'))
+        return om.getOrCreateContainer(self.name.lower(), parentObj=om.findObjectByName('scene'))
 
     def getRobotFolder(self, robotNum):
         return om.getOrCreateContainer('robot %d' % robotNum, parentObj=self.getRootFolder())

--- a/src/python/director/drakevisualizerapp.py
+++ b/src/python/director/drakevisualizerapp.py
@@ -2,6 +2,15 @@ import sys
 from director import drcargs
 from director import mainwindowapp
 
+# todo:
+# this check is required because openhumanoids
+# does not yet have robotlocomotion/lcmtypes
+try:
+    import robotlocomotion as lcmrl
+    HAVE_LCMRL = True
+except ImportError:
+    HAVE_LCMRL = False
+
 
 def main(globalsDict=None):
 
@@ -9,10 +18,13 @@ def main(globalsDict=None):
     app = mainwindowapp.MainWindowAppFactory().construct(globalsDict=globalsDict, windowTitle=appName, applicationName=appName)
 
     fact = mainwindowapp.MainWindowPanelFactory()
+
     options = fact.getDefaultOptions()
-    options.useLCMGLRenderer = True
-    fact.setDependentOptions(options, useTreeViewer=True)
-    fact.setDependentOptions(options, useDrakeVisualizer=True)
+    fact.setDependentOptions(options,
+        useTreeViewer=HAVE_LCMRL,
+        useDrakeVisualizer=True,
+        useLCMGLRenderer=True)
+
     fact.construct(options, app=app.app, view=app.view)
 
     if globalsDict is not None:

--- a/src/python/director/drakevisualizerapp.py
+++ b/src/python/director/drakevisualizerapp.py
@@ -5,33 +5,14 @@ from director import mainwindowapp
 
 def main(globalsDict=None):
 
-    if '--testing' not in sys.argv:
-        drcargs.requireStrict()
-
-    parser = drcargs.getGlobalArgParser().getParser()
-    parser.add_argument('--protocol', dest='visualizer_protocol', default='drake', type=str, help='Visualizer protocol (drake or json)')
-    args = drcargs.args()
-
-    knownProtocols = ('drake', 'json')
-    if args.visualizer_protocol not in knownProtocols:
-        print
-        print 'Unrecognized visualizer protocol:', args.visualizer_protocol
-        print 'Available protocols:', ', '.join(knownProtocols)
-        print
-        sys.exit(1)
-
     appName = 'Drake Visualizer'
     app = mainwindowapp.MainWindowAppFactory().construct(globalsDict=globalsDict, windowTitle=appName, applicationName=appName)
 
     fact = mainwindowapp.MainWindowPanelFactory()
     options = fact.getDefaultOptions()
     options.useLCMGLRenderer = True
-
-    if args.visualizer_protocol == 'json':
-        fact.setDependentOptions(options, useLCMVisualizer=True)
-    elif args.visualizer_protocol == 'drake':
-        fact.setDependentOptions(options, useDrakeVisualizer=True)
-
+    fact.setDependentOptions(options, useTreeViewer=True)
+    fact.setDependentOptions(options, useDrakeVisualizer=True)
     fact.construct(options, app=app.app, view=app.view)
 
     if globalsDict is not None:

--- a/src/python/director/drakevisualizerapp.py
+++ b/src/python/director/drakevisualizerapp.py
@@ -14,6 +14,9 @@ except ImportError:
 
 def main(globalsDict=None):
 
+    if '--testing' not in sys.argv:
+        drcargs.requireStrict()
+
     appName = 'Drake Visualizer'
     app = mainwindowapp.MainWindowAppFactory().construct(globalsDict=globalsDict, windowTitle=appName, applicationName=appName)
 

--- a/src/python/director/mainwindowapp.py
+++ b/src/python/director/mainwindowapp.py
@@ -348,7 +348,7 @@ class MainWindowPanelFactory(ComponentFactory):
         # these components depend on lcm and lcmgl, so they
         # are disabled by default
         options.useDrakeVisualizer = False
-        options.useLCMVisualizer = False
+        options.useTreeViewer = False
         options.useLCMGLRenderer = False
 
     def addComponents(self, componentGraph):
@@ -361,7 +361,7 @@ class MainWindowPanelFactory(ComponentFactory):
         addComponent('CameraBookmarksPanel', ['MainWindow'])
         addComponent('CameraControlPanel', ['MainWindow'])
         addComponent('DrakeVisualizer', ['MainWindow'])
-        addComponent('LCMVisualizer', ['MainWindow'])
+        addComponent('TreeViewer', ['MainWindow'])
         addComponent('LCMGLRenderer', ['MainWindow'])
 
     def initMainWindow(self, fields):
@@ -407,21 +407,21 @@ class MainWindowPanelFactory(ComponentFactory):
         from director import drakevisualizer
         drakeVisualizer = drakevisualizer.DrakeVisualizer(fields.view)
 
-        applogic.MenuActionToggleHelper('Tools', 'Drake Visualizer', drakeVisualizer.isEnabled, drakeVisualizer.setEnabled)
+        applogic.MenuActionToggleHelper('Tools', drakeVisualizer.name, drakeVisualizer.isEnabled, drakeVisualizer.setEnabled)
 
         return FieldContainer(
           drakeVisualizer=drakeVisualizer
           )
 
-    def initLCMVisualizer(self, fields):
+    def initTreeViewer(self, fields):
 
-        from director import drakevisualizer2
-        lcmVisualizer = drakevisualizer2.DrakeVisualizer(fields.view)
+        from director import treeviewer
+        treeViewer = treeviewer.TreeViewer(fields.view)
 
-        applogic.MenuActionToggleHelper('Tools', 'LCM Visualizer', lcmVisualizer.isEnabled, lcmVisualizer.setEnabled)
+        applogic.MenuActionToggleHelper('Tools', treeViewer.name, treeViewer.isEnabled, treeViewer.setEnabled)
 
         return FieldContainer(
-          lcmVisualizer=lcmVisualizer
+          treeViewer=treeViewer
           )
 
     def initLCMGLRenderer(self, fields):

--- a/src/python/director/treeviewer.py
+++ b/src/python/director/treeviewer.py
@@ -514,7 +514,7 @@ class TreeViewer(object):
         return path
 
     def getRootFolder(self):
-        return om.getOrCreateContainer(self.name,
+        return om.getOrCreateContainer(self.name.lower(),
                                        parentObj=om.findObjectByName('scene'))
 
     def getItemByPath(self, path):

--- a/src/python/director/treeviewer.py
+++ b/src/python/director/treeviewer.py
@@ -344,7 +344,9 @@ def findPathToAncestor(fromItem, toItem):
     return path
 
 
-class DrakeVisualizer(object):
+class TreeViewer(object):
+    name = "Remote Tree Viewer"
+
     def __init__(self, view):
 
         self.subscribers = []
@@ -357,7 +359,7 @@ class DrakeVisualizer(object):
 
     def _addSubscribers(self):
         self.subscribers.append(lcmUtils.addSubscriber(
-            'DRAKE_VIEWER2_REQUEST',
+            'DIRECTOR_TREE_VIEWER_REQUEST',
             lcmrl.viewer2_comms_t,
             self.onViewerRequest))
 
@@ -383,28 +385,28 @@ class DrakeVisualizer(object):
 
     def sendStatusMessage(self, timestamp, response):
         msg = lcmrl.viewer2_comms_t()
-        msg.format = "viewer2_json"
+        msg.format = "treeviewer_json"
         msg.format_version_major = 1
         msg.format_version_minor = 0
         data = dict(timestamp=timestamp, **response.toJson())
         msg.data = json.dumps(data)
         msg.num_bytes = len(msg.data)
-        lcmUtils.publish('DRAKE_VIEWER2_RESPONSE', msg)
+        lcmUtils.publish('DIRECTOR_TREE_VIEWER_RESPONSE', msg)
 
     def decodeCommsMsg(self, msg):
-        if msg.format == "viewer2_json":
+        if msg.format == "treeviewer_json":
             if msg.format_version_major == 1 and msg.format_version_minor == 0:
                 data = json.loads(msg.data)
                 return data, ViewerResponse(ViewerStatus.OK, {})
             else:
                 return None, ViewerResponse(ViewerStatus.ERROR_UNKNOWN_FORMAT_VERSION,
                                             {"supported_formats": {
-                                                 "viewer2_json": ["1.0"]
+                                                 "treeviewer_json": ["1.0"]
                                             }})
         else:
             return None, ViewerResponse(ViewerStatus.ERROR_UNKNOWN_FORMAT,
                                         {"supported_formats": {
-                                             "viewer2_json": ["1.0"]
+                                             "treeviewer_json": ["1.0"]
                                         }})
 
     def onViewerRequest(self, msg):
@@ -512,7 +514,7 @@ class DrakeVisualizer(object):
         return path
 
     def getRootFolder(self):
-        return om.getOrCreateContainer('drake viewer',
+        return om.getOrCreateContainer(self.name,
                                        parentObj=om.findObjectByName('scene'))
 
     def getItemByPath(self, path):

--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ set(python_tests_core
 set(python_tests_lcm
   testDrakeVisualizer.py
   testDrakeVisualizerInterface.py
-  testDrakeVisualizer2Interface.py
+  testTreeViewerInterface.py
 )
 
 set(python_tests_robot

--- a/src/python/tests/testTreeViewerInterface.py
+++ b/src/python/tests/testTreeViewerInterface.py
@@ -11,7 +11,7 @@ import robotlocomotion as lcmrl
 
 def comms_msg(timestamp, data):
     msg = lcmrl.viewer2_comms_t()
-    msg.format = "viewer2_json"
+    msg.format = "treeviewer_json"
     msg.format_version_major = 1
     msg.format_version_minor = 0
     encoded = json.dumps(data)
@@ -28,7 +28,7 @@ class Visualizer:
         for (path, geom) in geometries.items():
             self.load(path, geom)
         self.lcm = lcm.LCM()
-        self.lcm.subscribe("DRAKE_VIEWER2_RESPONSE", self.onResponse)
+        self.lcm.subscribe("DIRECTOR_TREE_VIEWER_RESPONSE", self.onResponse)
         self.listener = threading.Thread(target=self.listen)
         self.listener.daemon = True
         self.listener.start()
@@ -46,7 +46,7 @@ class Visualizer:
             "draw": self.queue["draw"]
         }
         msg = comms_msg(timestamp, data)
-        self.lcm.publish("DRAKE_VIEWER2_REQUEST", msg.encode())
+        self.lcm.publish("DIRECTOR_TREE_VIEWER_REQUEST", msg.encode())
         self.queue["load"] = []
         self.queue["delete"] = []
         self.queue["draw"] = []


### PR DESCRIPTION
* changes all internal variants of drakevisualizer2 and viewer2 to treeviewer
* changes LCM channels to `DRAKE_TREE_VIEWER_{REQUEST|RESPONSE}`
* enables both the (old) drakevisualizer and (new) treeviewer in the drake-visualizer app, since they use separate LCM channels
