### PR TITLE
rename load -> setgeometry and draw -> settransform and fix polyDataItem properties

### DIFF
--- a/src/python/director/treeviewer.py
+++ b/src/python/director/treeviewer.py
@@ -445,9 +445,15 @@ class TreeViewer(object):
         missingPaths = set()
         for command in data["delete"]:
             deletedPaths.add(tuple(self.handleDeletePath(command)))
-        for command in data["load"]:
-            addedGeometries.add(tuple(self.handleAddGeometry(command)))
-        for command in data["draw"]:
+        if "load" in data:
+            warnings.warn("The 'load' comand has been deprecated. Please use 'setgeometry' instead", DeprecationWarning)
+            data["setgeometry"] = data["load"]
+        if "draw" in data:
+            warnings.warn("The 'draw' cmmand has been deprecated. Please use 'settransform' instead", DeprecationWarning)
+            data["settransform"] = data["draw"]
+        for command in data["setgeometry"]:
+            addedGeometries.add(tuple(self.handleSetGeometry(command)))
+        for command in data["settransform"]:
             path, missingGeometry = self.handleSetTransform(command)
             setTransforms.add(tuple(path))
             if missingGeometry:

--- a/src/python/tests/testTreeViewerClient.py
+++ b/src/python/tests/testTreeViewerClient.py
@@ -28,11 +28,11 @@ if __name__ == '__main__':
     # We can provide an initial path if we want
     vis = Visualizer(path="/root/folder1")
 
-
-    vis["boxes"].load([GeometryData(Box([1, 1, 1]),
-                           color=np.hstack((np.random.rand(3), 0.5)),
-                           transform=transformations.translation_matrix([x, -2, 0])) \
-                       for x in range(10)])
+    vis["boxes"].setgeometry(
+        [GeometryData(Box([1, 1, 1]),
+                      color=np.hstack((np.random.rand(3), 0.5)),
+                      transform=transformations.translation_matrix([x, -2, 0]))
+         for x in range(10)])
 
     # Index into the visualizer to get a sub-tree. vis.__getitem__ is lazily
     # implemented, so these sub-visualizers come into being as soon as they're
@@ -44,13 +44,13 @@ if __name__ == '__main__':
 
     box = Box([1, 1, 1])
     geom = GeometryData(box, color=[0, 1, 0, 0.5])
-    box_vis.load(geom)
+    box_vis.setgeometry(geom)
 
-    sphere_vis.load(Sphere(1.0))
-    sphere_vis.draw(transformations.translation_matrix([1, 0, 0]))
+    sphere_vis.setgeometry(Sphere(1.0))
+    sphere_vis.settransform(transformations.translation_matrix([1, 0, 0]))
 
     for theta in np.linspace(0, 2 * np.pi, 100):
-        vis.draw(transformations.rotation_matrix(theta, [0, 0, 1]))
+        vis.settransform(transformations.rotation_matrix(theta, [0, 0, 1]))
         time.sleep(0.01)
     sphere_vis.delete()
 


### PR DESCRIPTION
Deprecates the old `load()` and `draw()` commands, so they'll still work for now but will issue warnings. 

Fixes #452 

Also creates fewer unnecessary polyDataItems, which means that copying properties from one polyDataItem to another is no longer necessary, which fixes #451 