### PR TITLE
don't try to generate empty meshes

### DIFF
--- a/src/python/director/treeviewer.py
+++ b/src/python/director/treeviewer.py
@@ -176,18 +176,20 @@ class Geometry(object):
     def createPolyDataFromMeshArrays(pts, faces):
         pd = vtk.vtkPolyData()
         pd.SetPoints(vtk.vtkPoints())
-        pd.GetPoints().SetData(vnp.getVtkFromNumpy(pts.copy()))
 
-        cells = vtk.vtkCellArray()
-        for face in faces:
-            assert len(face) == 3, "Non-triangular faces are not supported."
-            tri = vtk.vtkTriangle()
-            tri.GetPointIds().SetId(0, face[0])
-            tri.GetPointIds().SetId(1, face[1])
-            tri.GetPointIds().SetId(2, face[2])
-            cells.InsertNextCell(tri)
+        if pts.size > 0:
+            pd.GetPoints().SetData(vnp.getVtkFromNumpy(pts.copy()))
 
-        pd.SetPolys(cells)
+            cells = vtk.vtkCellArray()
+            for face in faces:
+                assert len(face) == 3, "Non-triangular faces are not supported."
+                tri = vtk.vtkTriangle()
+                tri.GetPointIds().SetId(0, face[0])
+                tri.GetPointIds().SetId(1, face[1])
+                tri.GetPointIds().SetId(2, face[2])
+                cells.InsertNextCell(tri)
+
+            pd.SetPolys(cells)
         return pd
 
     @staticmethod

--- a/src/python/director/treeviewer.py
+++ b/src/python/director/treeviewer.py
@@ -181,12 +181,13 @@ class Geometry(object):
             pd.GetPoints().SetData(vnp.getVtkFromNumpy(pts.copy()))
 
             cells = vtk.vtkCellArray()
+            tri = vtk.vtkTriangle()
+            setId = tri.GetPointIds().SetId  # bind the method for convenience
             for face in faces:
                 assert len(face) == 3, "Non-triangular faces are not supported."
-                tri = vtk.vtkTriangle()
-                tri.GetPointIds().SetId(0, face[0])
-                tri.GetPointIds().SetId(1, face[1])
-                tri.GetPointIds().SetId(2, face[2])
+                setId(0, face[0])
+                setId(1, face[1])
+                setId(2, face[2])
                 cells.InsertNextCell(tri)
 
             pd.SetPolys(cells)


### PR DESCRIPTION
Fixes an ultimately harmless but annoying error message:

```
ERROR: In /tmp/vtk5-20160602-81757-1afa8z2/VTK5.10.1/Common/vtkPoints.cxx, line 172
vtkPoints (0x7f8ed5054fd0): Number of components is different...can't set data
```

when trying to construct a mesh with zero points. 