### PR TITLE
call interpolate.PchipInterpolator instead of interpolate.pchip alias

### DIFF
--- a/src/python/director/planplayback.py
+++ b/src/python/director/planplayback.py
@@ -107,7 +107,7 @@ class PlanPlayback(object):
         if self.interpolationMethod in ['slinear', 'quadratic', 'cubic']:
             f = scipy.interpolate.interp1d(poseTimes, poses, axis=0, kind=self.interpolationMethod)
         elif self.interpolationMethod == 'pchip':
-            f = scipy.interpolate.pchip(poseTimes, poses, axis=0)
+            f = scipy.interpolate.PchipInterpolator(poseTimes, poses, axis=0)
         return f
 
 
@@ -223,7 +223,7 @@ class PlanPlayback(object):
             if self.interpolationMethod in ['slinear', 'quadratic', 'cubic']:
                 f = scipy.interpolate.interp1d(x, y, kind=self.interpolationMethod)
             elif self.interpolationMethod == 'pchip':
-                f = scipy.interpolate.pchip(x, y)
+                f = scipy.interpolate.PchipInterpolator(x, y)
 
             ax.plot(x, y, 'ko')
             seriesNames.append(jointName + ' points')

--- a/src/python/director/pydrakeik.py
+++ b/src/python/director/pydrakeik.py
@@ -475,7 +475,7 @@ class PyDrakeIkServer(object):
         '''
         Given arrays x and y and an interpolation kind 'linear', 'cubic' or 'pchip',
         this function returns the result of scipy.interpolate.interp1d or
-        scipy.interpolate.pchip.
+        scipy.interpolate.PchipInterpolator.
 
         If the interpolation is cubic or pchip, this function will duplicate the
         values at the end points of x and y (and add/subtract a very small x delta)
@@ -498,7 +498,7 @@ class PyDrakeIkServer(object):
             y = np.vstack(([y[0]], y, [y[-1]]))
 
         if kind == 'pchip':
-            return scipy.interpolate.pchip(x, y, axis=0)
+            return scipy.interpolate.PchipInterpolator(x, y, axis=0)
         else:
             return scipy.interpolate.interp1d(x, y, axis=0, kind=kind)
 


### PR DESCRIPTION
The interpolate.pchip is just an alias of PchipInterpolator and does not
exist in older versions of scipy.