### PR TITLE
Add a unique client_id to the channel name in the treeviewer protocol

### DIFF
--- a/src/python/director/viewerclient.py
+++ b/src/python/director/viewerclient.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import time
 import json
+import os
 import tempfile
 import threading
 from collections import defaultdict, namedtuple, Iterable
@@ -9,6 +10,19 @@ import numpy as np
 from lcm import LCM
 from robotlocomotion import viewer2_comms_t
 from director.thirdparty import transformations
+
+
+class ClientIDFactory(object):
+    def __init__(self):
+        self.pid = os.getpid()
+        self.counter = 0
+
+    def new_client_id(self):
+        self.counter += 1
+        return "py_{:d}_{:d}".format(self.pid, self.counter)
+
+
+CLIENT_ID_FACTORY = ClientIDFactory()
 
 
 def to_lcm(data):
@@ -206,7 +220,7 @@ class CoreVisualizer(object):
         if lcm is None:
             lcm = LCM()
         self.lcm = lcm
-        self.client_id_file = tempfile.NamedTemporaryFile()
+        self.client_id = CLIENT_ID_FACTORY.new_client_id()
         self.tree = LazyTree()
         self.queue = CommandQueue()
         self.publish_immediately = True
@@ -215,10 +229,10 @@ class CoreVisualizer(object):
         self.handler_thread = None
 
     def _request_channel(self):
-        return "DIRECTOR_TREE_VIEWER_REQUEST_<{:s}>".format(self.client_id_file.name)
+        return "DIRECTOR_TREE_VIEWER_REQUEST_<{:s}>".format(self.client_id)
 
     def _response_channel(self):
-        return "DIRECTOR_TREE_VIEWER_RESPONSE_<{:s}>".format(self.client_id_file.name)
+        return "DIRECTOR_TREE_VIEWER_RESPONSE_<{:s}>".format(self.client_id)
 
     def _handler_loop(self):
         while True:

--- a/src/python/tests/testTreeViewerInterface.py
+++ b/src/python/tests/testTreeViewerInterface.py
@@ -30,7 +30,7 @@ class Visualizer:
         for (path, geom) in geometries.items():
             self.setgeometry(path, geom)
         self.lcm = lcm.LCM()
-        self.lcm.subscribe("DIRECTOR_TREE_VIEWER_RESPONSE_<foo>", self.onResponse)
+        self.lcm.subscribe("DIRECTOR_TREE_VIEWER_RESPONSE", self.onResponse)
         self.listener = threading.Thread(target=self.listen)
         self.listener.daemon = True
         self.listener.start()
@@ -48,7 +48,7 @@ class Visualizer:
             "settransform": self.queue["settransform"]
         }
         msg = comms_msg(timestamp, data)
-        self.lcm.publish("DIRECTOR_TREE_VIEWER_REQUEST_<foo>", msg.encode())
+        self.lcm.publish("DIRECTOR_TREE_VIEWER_REQUEST", msg.encode())
         self.queue["setgeometry"] = []
         self.queue["delete"] = []
         self.queue["settransform"] = []

--- a/src/python/tests/testTreeViewerInterface.py
+++ b/src/python/tests/testTreeViewerInterface.py
@@ -30,7 +30,7 @@ class Visualizer:
         for (path, geom) in geometries.items():
             self.setgeometry(path, geom)
         self.lcm = lcm.LCM()
-        self.lcm.subscribe("DIRECTOR_TREE_VIEWER_RESPONSE", self.onResponse)
+        self.lcm.subscribe("DIRECTOR_TREE_VIEWER_RESPONSE_<foo>", self.onResponse)
         self.listener = threading.Thread(target=self.listen)
         self.listener.daemon = True
         self.listener.start()
@@ -48,7 +48,7 @@ class Visualizer:
             "settransform": self.queue["settransform"]
         }
         msg = comms_msg(timestamp, data)
-        self.lcm.publish("DIRECTOR_TREE_VIEWER_REQUEST", msg.encode())
+        self.lcm.publish("DIRECTOR_TREE_VIEWER_REQUEST_<foo>", msg.encode())
         self.queue["setgeometry"] = []
         self.queue["delete"] = []
         self.queue["settransform"] = []


### PR DESCRIPTION
cc @patmarion 

Clients should send requests on `DIRECTOR_TREE_VIEWER_REQUEST_<foo>` and listen on `DIRECTOR_TREE_VIEWER_RESPONSE_<foo>`. The old behavior will still work, but raises a deprecation warning. 

This also updates `viewerclient.py` to follow the new protocol (using a unique temporary filename as its client ID). `testTreeViewerInterface.py`, however, is still testing the deprecated protocol (for now). 