### PR TITLE
Support lines and arrows in the tree viewer interface

### DIFF
--- a/src/python/director/debugVis.py
+++ b/src/python/director/debugVis.py
@@ -93,20 +93,22 @@ class DebugData(object):
             edges.Update()
             self.addPolyData(edges.GetOutput(), color)
 
-    def addArrow(self, start, end, headRadius=0.05, tubeRadius=0.01, color=[1,1,1], startHead=False, endHead=True):
+    def addArrow(self, start, end, headRadius=0.05, headLength=None, tubeRadius=0.01, color=[1,1,1], startHead=False, endHead=True):
+        if headLength is None:
+            headLength = headRadius
         normal = np.array(end) - np.array(start)
         normal = normal / np.linalg.norm(normal)
         if startHead:
-            start = np.array(start) + headRadius * normal
+            start = np.array(start) + 0.5 * headLength * normal
         if endHead:
-            end = np.array(end) - headRadius * normal
+            end = np.array(end) - 0.5 * headLength * normal
         self.addLine(start, end, radius=tubeRadius, color=color)
         if startHead:
             self.addCone(origin=start, normal=-normal, radius=headRadius,
-                         height=headRadius, color=color, fill=True)
+                         height=headLength, color=color, fill=True)
         if endHead:
             self.addCone(origin=end, normal=normal, radius=headRadius,
-                         height=headRadius, color=color, fill=True)
+                         height=headLength, color=color, fill=True)
 
     def addSphere(self, center, radius=0.05, color=[1,1,1], resolution=24):
 

--- a/src/python/director/debugVis.py
+++ b/src/python/director/debugVis.py
@@ -58,6 +58,12 @@ class DebugData(object):
             tube.Update()
             self.addPolyData(tube.GetOutput(), color)
 
+    def addPolyLine(self, points, isClosed=False, radius=0.0, color=[1,1,1]):
+        for (p1, p2) in zip(points[:-1], points[1:]):
+            self.addLine(p1, p2, radius=radius, color=color)
+        if isClosed:
+            self.addLine(points[-1], points[0], radius=radius, color=color)
+
     def addFrame(self, frame, scale, tubeRadius=0.0):
 
         origin = np.array([0.0, 0.0, 0.0])

--- a/src/python/director/treeviewer.py
+++ b/src/python/director/treeviewer.py
@@ -148,6 +148,32 @@ class Geometry(object):
         return [polyData]
 
     @staticmethod
+    def createPolyLine(params):
+        d = DebugData()
+        points = [np.asarray(p) for p in params["points"]]
+        color = params.get("color", [1, 1, 1])[:3]
+        radius = params.get("radius", 0.01)
+        startHead = params.get("start_head", False)
+        endHead = params.get("end_head", False)
+        headRadius = params.get("head_radius", 0.05)
+        headLength = params.get("head_length", headRadius)
+        isClosed = params.get("closed", False)
+        if startHead:
+            normal = points[0] - points[1]
+            normal = normal / np.linalg.norm(normal)
+            points[0] = points[0] - 0.5 * headLength * normal
+            d.addCone(origin=points[0], normal=normal, radius=headRadius,
+                      height=headLength, color=color, fill=True)
+        if endHead:
+            normal = points[-1] - points[-2]
+            normal = normal / np.linalg.norm(normal)
+            points[-1] = points[-1] - 0.5 * headLength * normal
+            d.addCone(origin=points[-1], normal=normal, radius=headRadius,
+                      height=headLength, color=color, fill=True)
+        d.addPolyLine(points, isClosed, radius=radius, color=color)
+        return [d.getPolyData()]
+
+    @staticmethod
     def createPolyData(params):
         if params["type"] == "box":
             return Geometry.createBox(params)
@@ -169,6 +195,8 @@ class Geometry(object):
             return Geometry.createPlanarLidar(params)
         elif params["type"] == "triad":
             return Geometry.createTriad(params)
+        elif params["type"] == "line":
+            return Geometry.createPolyLine(params)
         else:
             raise Exception(
                 "Unsupported geometry type: {}".format(params["type"]))

--- a/src/python/director/viewerclient.py
+++ b/src/python/director/viewerclient.py
@@ -102,6 +102,32 @@ class Triad(BaseGeometry, namedtuple("Triad", [])):
             "type": "triad"
         }
 
+class PolyLine(BaseGeometry):
+    def __init__(self, points, radius=0.01, closed=False,
+                 start_head=False, end_head=False,
+                 head_radius=0.05, head_length=None):
+        self.points = points
+        self.radius = radius
+        self.closed = closed
+        self.start_head = start_head
+        self.end_head = end_head
+        self.head_radius = head_radius
+        self.head_length = head_length if head_length is not None else head_radius
+
+    def serialize(self):
+        data = {
+            "type": "line",
+            "points": self.points,
+            "radius": self.radius,
+            "closed": self.closed
+        }
+        if self.start_head or self.end_head:
+            data["start_head"] = self.start_head
+            data["end_head"] = self.end_head
+            data["head_radius"] = self.head_radius
+            data["head_length"] = self.head_length
+        return data
+
 
 class LazyTree(object):
     __slots__ = ["geometries", "transform", "children"]

--- a/src/python/tests/CMakeLists.txt
+++ b/src/python/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(python_tests_standalone
 if(NOT USE_DRC)
   list(APPEND python_tests_lcm testTreeViewerInterface.py)
   list(APPEND python_tests_lcm testTreeViewerClient.py)
+  list(APPEND python_tests_lcm testTreeViewerPolyLine.py)
 endif()
 
 

--- a/src/python/tests/testTreeViewerPolyLine.py
+++ b/src/python/tests/testTreeViewerPolyLine.py
@@ -1,0 +1,43 @@
+import time
+import os
+import subprocess
+
+import numpy as np
+import lcm
+from director.thirdparty import transformations
+from director.viewerclient import Visualizer, PolyLine, GeometryData
+
+
+if __name__ == '__main__':
+    # We'll open the visualizer by spawning it as a subprocess. See
+    # testDrakeVisualizer.py for an example of how to spawn it within Python
+    # instead.
+    vis_binary = os.path.join(os.path.dirname(sys.executable),
+                              "drake-visualizer")
+
+    # The viewer will take some time to load before it is ready to receive
+    # messages, so we'll wait until it sends its first status message.
+    print "waiting for viewer to initialize"
+    lc = lcm.LCM()
+    lc.subscribe("DIRECTOR_TREE_VIEWER_RESPONSE", lambda c, d: None)
+    vis_process = subprocess.Popen([vis_binary, '--testing', '--interactive'])
+
+    # Wait for one LCM message to be received.
+    lc.handle()
+
+    vis = Visualizer("lines")
+
+
+    vis["basic_line"].setgeometry(PolyLine([[0, 0, 0], [0, 0, 1]]))
+
+    vis["arrow_end"].setgeometry(PolyLine([[.1, 0, 0], [.1, 0, 1]], end_head=True))
+
+    vis["arrow_start"].setgeometry(PolyLine([[-.1, 0, 0], [-.1, 0, 1]], start_head=True))
+
+    vis["loop"].setgeometry(PolyLine([[1, 0, 0], [1, 1, 0.5], [1, 0, 1]], closed=True))
+
+    vis["poly_arrow"].setgeometry(PolyLine([[0, 1, 0], [0, 1, 1], [-1, 1, 1]], start_head=True, end_head=True))
+
+    vis["colored_hairline"].setgeometry(GeometryData(PolyLine([[0, -1, 0], [0, -1, 1]], radius=0), color=[0, 0.2, 0.8, 0.5]))
+
+    vis["sharp_arrow"].setgeometry(PolyLine([[-1, 0, 0.5], [-0.5, 0, 0.5]], end_head=True, head_length=0.2))

--- a/src/python/tests/testTreeViewerPolyLine.py
+++ b/src/python/tests/testTreeViewerPolyLine.py
@@ -41,3 +41,5 @@ if __name__ == '__main__':
     vis["colored_hairline"].setgeometry(GeometryData(PolyLine([[0, -1, 0], [0, -1, 1]], radius=0), color=[0, 0.2, 0.8, 0.5]))
 
     vis["sharp_arrow"].setgeometry(PolyLine([[-1, 0, 0.5], [-0.5, 0, 0.5]], end_head=True, head_length=0.2))
+
+    vis_process.terminate()


### PR DESCRIPTION
Fixes #473 

Adds the "line" type to the JSON interface which can consist of an arbitrary number of points, plus options to determine whether to close the loop and whether to draw arrow heads at the start or end of the line. 

Also, fixes the arrow head length calculation, so arrows now end with their point exactly at the target point, rather than 0.5 * headRadius away. 