### PR TITLE
Add non-conservative set of dependencies for Ubuntu 16.04

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,12 @@ The dependencies can be installed on Ubuntu using apt-get:
 
     sudo apt-get install cmake libvtk5-qt4-dev libeigen3-dev python-dev python-vtk python-numpy
 
+If you are running Ubuntu 16.04, please install the following non-conservative set of
+dependencies by executing:
+
+::
+
+    ./distro/pods/drake-distro/install_prereqs.sh ubuntu_16_04
 
 Building
 ========

--- a/distro/pods/drake-distro/install_prereqs.sh
+++ b/distro/pods/drake-distro/install_prereqs.sh
@@ -13,6 +13,74 @@ case $1 in
     port install vtk5 +qt4_mac +python27 ;;
   ("ubuntu")
     apt-get install libqt4-dev libvtk5-dev libvtk5-qt4-dev python-vtk python-numpy ;;
+  ("ubuntu_16_04")
+    apt install \
+      build-essential \
+      cmake \
+      debhelper \
+      doxygen \
+      f2c \
+      freeglut3-dev \
+      gfortran \
+      graphviz \
+      gtk-doc-tools \
+      libblas-dev \
+      libboost-filesystem-dev \
+      libboost-iostreams-dev \
+      libboost-program-options-dev \
+      libboost-random-dev \
+      libboost-regex-dev \
+      libboost-signals-dev \
+      libboost-system-dev \
+      libboost-thread-dev \
+      libf2c2-dev \
+      libfreeimage-dev \
+      libglew-dev \
+      libglib2.0-dev \
+      libgmp3-dev \
+      libgsl0-dev \
+      libgtkmm-2.4-dev \
+      liblapack-dev \
+      libltdl-dev \
+      libopenni-dev \
+      libportmidi-dev \
+      libprotobuf-dev \
+      libprotoc-dev \
+      libqglviewer-dev \
+      libqhull-dev \
+      libqt4-dev \
+      libqwt-dev \
+      libsdl1.2-dev \
+      libspnav-dev \
+      libsuitesparse-dev \
+      libtar-dev \
+      libtbb-dev \
+      libterm-readkey-perl \
+      libtinyxml-dev \
+      libusb-1.0-0-dev \
+      libv4l-dev \
+      libvtk5-dev \
+      libvtk5-qt4-dev \
+      libwww-perl \
+      libx264-dev \
+      libxml2-dev \
+      libxmu-dev \
+      mercurial \
+      ncurses-dev \
+      pkg-config \
+      protobuf-compiler \
+      python-dev \
+      python-matplotlib \
+      python-numpy \
+      python-pip \
+      python-pygame \
+      python-pymodbus \
+      python-scipy \
+      python-vtk \
+      python-yaml \
+      spacenavd \
+      subversion \
+      swig
   ("cygwin")
     echo "WARNING: install_prereqs cygwin not implemented for this module" ;;
   (*)
@@ -21,6 +89,7 @@ case $1 in
     echo "  homebrew"
     echo "  macports"
     echo "  ubuntu"
+    echo "  ubuntu_16_04"
     echo "  cygwin"
     exit 1 ;;
 esac


### PR DESCRIPTION
This adds a non-conservative set of dependencies for installing on Ubuntu 16.04 for a development machine.

Drawn from `oh-distro`:
https://github.com/openhumanoids/oh-distro/blob/eeee1d8/README.rst#dependencies

I have added this to `drake-distro`'s pods install script as a very rough start, but please let me know if these prereqs should be listed elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/director/500)
<!-- Reviewable:end -->
