### PR TITLE
update WrapPythonQt.py

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -253,6 +253,6 @@ add_custom_command(OUTPUT ${decorator_file}
   -i ${wrap_files} -o "${decorator_file}"
   --class-prefixes vtk dd QVTK --qt-class-prefixes dd QVTK
   --export-header ddAppConfigure.h --export-symbol DD_APP_EXPORT
-  --module-name dd
+  --auto-class-includes --module-name dd
   DEPENDS ${wrap_files} WrapPythonQt.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/app/WrapPythonQt.py
+++ b/src/app/WrapPythonQt.py
@@ -3,8 +3,17 @@ import re
 import sys
 import argparse
 
-def wrap(inFileNames, outFileName, exportSymbol, exportHeader, classNamePrefixes, qtClassNamePrefixes, moduleName):
+def wrap(args):
 
+
+    inFileNames = args.input_file
+    outFileName = args.output_file
+    exportSymbol = args.export_symbol
+    exportHeader = args.export_header
+    classNamePrefixes = args.class_prefixes
+    qtClassNamePrefixes = args.qt_class_prefixes
+    moduleName = args.module_name
+    autoClassIncludes = args.auto_class_includes
 
     if not outFileName.endswith('.h'):
         raise Exception('Error: output file extension must be .h')
@@ -115,7 +124,11 @@ def wrap(inFileNames, outFileName, exportSymbol, exportHeader, classNamePrefixes
 
     sortedClasses = list(includeClasses)
     sortedClasses.sort()
-    classIncludes = "\n".join(['#include "%s.h"' % className for className in sortedClasses] + includeLines)
+
+    if autoClassIncludes:
+        classIncludes = "\n".join(['#include "%s.h"' % className for className in sortedClasses] + includeLines)
+    else:
+        classIncludes = ""
     classRegisters = "\n".join(['    this->registerClassForPythonQt(&%s::staticMetaObject);' % className
                                 for className in sortedClasses if className.startswith(qtClassNamePrefixes)])
 
@@ -171,7 +184,6 @@ public slots:
 
 def main():
 
-
     parser = argparse.ArgumentParser(description='Generate a PythonQt decorator class file from a list of method signatures.')
     parser.add_argument('--input-file', '-i', nargs='+', required=True, help='A text file with method signatures, one per line.')
     parser.add_argument('--output-file', '-o', required=True, help='The output filename.  The file extension should be .h')
@@ -180,10 +192,11 @@ def main():
     parser.add_argument('--export-header', default='', help='A header filename that defines an export symbol.')
     parser.add_argument('--class-prefixes', nargs='*', help='A list of class name prefixes.')
     parser.add_argument('--qt-class-prefixes', nargs='*', help='A list of Qt class name prefixes.')
+    parser.add_argument('--auto-class-includes', action='store_true', help='Automatically generate include statements from class names.')
 
     args = parser.parse_args()
 
-    wrap(args.input_file, args.output_file, args.export_symbol, args.export_header, args.class_prefixes, args.qt_class_prefixes, args.module_name)
+    wrap(args)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Adds --auto-class-includes option to determine whether or not the wrapper
should automatically guess the header given a class name.  This option
works well for Director source files but other projects may have different
naming conventions.