### PR TITLE
[WIP] Add basic synchronized video frame recording, for use with LcmLogPlayer

### DIFF
--- a/src/python/director/lcmlogplayer.py
+++ b/src/python/director/lcmlogplayer.py
@@ -149,41 +149,59 @@ class LcmLogPlayerGui(object):
         stopButton = QtGui.QPushButton('Stop')
         slider = QtGui.QSlider(QtCore.Qt.Horizontal)
         slider.maximum = int(logPlayer.getEndTime()*100)
+        text = QtGui.QLineEdit()
+        text.text = '0.0'
         playButton.connect('clicked()', self.onPlay)
         stopButton.connect('clicked()', self.onStop)
         slider.connect('valueChanged(int)', self.onSlider)
+        text.connect('returnPressed()', self.onText)
 
         l = QtGui.QHBoxLayout(w)
         l.addWidget(slider)
+        l.addWidget(text)
         l.addWidget(playButton)
         l.addWidget(stopButton)
 
         self.slider = slider
+        self.text = text
         self.widget = w
         self.widget.show()
 
-    def _getTime(self, value=None):
+    def _getSliderTime(self, value=None):
         if value is None:
             value = self.slider.value
         t = self.logPlayer.getEndTime()*value/self.slider.maximum
         return t
 
-    def _getValue(self, t):
+    def _getSliderValue(self, t):
         value = t / self.logPlayer.getEndTime() * self.slider.maximum
         return int(round(value))
 
+    def _updateTime(self, t):
+        with BlockSignals(self.slider, self.text):
+            self.slider.value = self._getSliderValue(t)
+            self.text.text = str(t)
+
     def onPlay(self):
-        def onFrame(t):
-            with BlockSignals(self.slider):
-                self.slider.value = self._getValue(t)
-        self.logPlayer.playback(self._getTime(), self.logPlayer.getEndTime(), onFrame)
+        self.logPlayer.playback(self._getSliderTime(), self.logPlayer.getEndTime(), self._updateTime)
 
     def onStop(self):
         self.logPlayer.timer.stop()
 
-    def onSlider(self, value):
-        t = self._getTime(value)
+    def skipTo(self, t):
+        self._updateTime(t)
         self.logPlayer.skipToTime(t, playLength=0.0)
+
+    def onSlider(self, value):
+        t = self._getSliderTime(value)
+        self.skipTo(t)
+
+    def onText(self, *args):
+        try:
+            t = float(self.text.text)
+            self.skipTo(t)
+        except ValueError:
+            pass
 
 # @ref https://stackoverflow.com/a/35000974/7829525
 class BlockSignals(object):

--- a/src/python/director/lcmlogplayer.py
+++ b/src/python/director/lcmlogplayer.py
@@ -1,5 +1,6 @@
 from director import lcmUtils
 from director.timercallback import TimerCallback
+from director.qtutils import BlockSignals
 
 import lcm
 import numpy as np
@@ -202,18 +203,6 @@ class LcmLogPlayerGui(object):
             self.skipTo(t)
         except ValueError:
             pass
-
-# @ref https://stackoverflow.com/a/35000974/7829525
-class BlockSignals(object):
-    def __init__(self, *args):
-        self.widgets = args
-    def blockSignals(self, value):
-        for widget in self.widgets:
-            widget.blockSignals(value)
-    def __enter__(self, *args, **kwargs):
-        self.blockSignals(True)
-    def __exit__(self, *args, **kwargs):
-        self.blockSignals(False)
 
 if __name__ == '__main__':
 

--- a/src/python/director/qtutils.py
+++ b/src/python/director/qtutils.py
@@ -26,3 +26,41 @@ def loadUi(filename):
     widget = loader.load(uifile)
     ui = WidgetDict(widget.children())
     return widget, ui
+
+# @ref https://stackoverflow.com/a/35000974/7829525
+class BlockSignals(object):
+    """
+    Block signals to a given set of objects using a `with` statement.
+
+    Example:
+    @code
+        class MyWidget(object):
+            def __init__(self):
+                text = QtGui.QLineEdit()
+                text.text = '0.0'
+                text.connect('returnPressed()', self.onTextUpdate)
+
+            def onTextUpdate(self, *args):
+                doSomethingIntenseAndExpensive(self.text.text)
+            def somethingElse(self):
+                # In some code that you wish to update the text, without doing something
+                # intense and expensive:
+                with BlockSignals(self.text):
+                    self.text.text = "Something Else"
+    @endcode
+
+    @see QObject.blockSignals(...)
+    """
+    def __init__(self, *args):
+        self.objects = args
+    def enable(self, value):
+        """
+        Block signals for all widgets.
+        @param value True or False, whether or not to block the signals.
+        """
+        for obj in self.objects:
+            obj.blockSignals(value)
+    def __enter__(self, *args, **kwargs):
+        self.enable(True)
+    def __exit__(self, *args, **kwargs):
+        self.enable(False)


### PR DESCRIPTION
Following comment in PR #522, this is a preliminary addition to start enabling recording deterministic videos (at least as far as I'm aware - please let me know if there's a better way!) such that a video should always have the same number of frames at the same time instants - with this current (hacky) PR, this is synchronized with LCM timestamps, such that you should effectively always produce the exact same video from an LCM Log.

An example application is blending between two videos with certain objects hidden, and not having to do any video synchronization.

My initial guess on improvements would be to separate the `SreenGrabberPanel` recording functionality in its own class, and maybe have that share some common Qt signal with the GUI elements, such that these singleton hacks aren't (as) necessary.

\cc @patmarion @sammy-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/director/525)
<!-- Reviewable:end -->
