### PR TITLE
fix symlink capitalization in mac package

### DIFF
--- a/distro/package/make_mac_package.sh
+++ b/distro/package/make_mac_package.sh
@@ -48,10 +48,10 @@ cd $scriptDir
 mkdir $packageName
 mv $bundleDir $packageName/
 cd $packageName
-ln -s $appName.app/Contents/MacOs/bin
-ln -s $appName.app/Contents/MacOs/lib
-ln -s $appName.app/Contents/MacOs/include
-ln -s $appName.app/Contents/MacOs/share
+ln -s $appName.app/Contents/MacOS/bin
+ln -s $appName.app/Contents/MacOS/lib
+ln -s $appName.app/Contents/MacOS/include
+ln -s $appName.app/Contents/MacOS/share
 
 # remove headers
 #find $appName.app -name \*.h | xargs rm


### PR DESCRIPTION
fixes #532 (I think). I can't actually test this without a case-sensitive file system, but I think this is the right fix. 