### PR TITLE
Initialize render window size in ddQVTKWidgetView constructor

### DIFF
--- a/src/app/ddQVTKWidgetView.cpp
+++ b/src/app/ddQVTKWidgetView.cpp
@@ -115,6 +115,7 @@ ddQVTKWidgetView::ddQVTKWidgetView(QWidget* parent) : ddViewBase(parent)
   this->Internal->RenderWindow->SetStereoTypeToRedBlue();
   this->Internal->RenderWindow->StereoRenderOff();
   this->Internal->RenderWindow->StereoUpdate();
+  this->Internal->RenderWindow->SetSize(width(), height());
 
   this->Internal->LightKit = vtkSmartPointer<vtkLightKit>::New();
   this->Internal->LightKit->SetKeyLightWarmth(0.5);


### PR DESCRIPTION
The render window size is updated when a QResizeEvent happen. At construction
time, the render window size is set to (0,0). This can cause problem if one
requests the size of the render window (e.g. to compute its aspect ratio)
before a QResizeEvent happen.