### PR TITLE
Replace `pydrake.getDrakePath()` with `pydrake.common.FindResourceOrT…

### DIFF
--- a/src/python/director/drcargs.py
+++ b/src/python/director/drcargs.py
@@ -84,18 +84,19 @@ class DRCArgParser(object):
             import pydrake
         except ImportError:
             return False
+        if 'DRAKE_RESOURCE_ROOT' not in os.environ:
+            return False
         return True
 
     def addDrakeConfigShortcuts(self, directorConfig):
 
         import pydrake
-        drakePath = pydrake.getDrakePath()
 
         directorConfig.add_argument(
             '--iiwa-drake',
             dest='directorConfigFile',
             action='store_const',
-            const=os.path.join(drakePath, 'examples/kuka_iiwa_arm/director_config.json'),
+            const=pydrake.common.FindResourceOrThrow('drake/examples/kuka_iiwa_arm/director_config.json'),
             help='Use KUKA IIWA from drake/examples')
 
     def addOpenHumanoidsConfigShortcuts(self, directorConfig):


### PR DESCRIPTION
…hrow(...)`

`pydrake.getDrakePath()` does not work with the install tree of drake built
with bazel. Instead, we can rely on `pydrake.common.FindResourceOrThrow(...)`
once the environment variable `DRAKE_RESOURCE_ROOT` is defined.