### PR TITLE
start the mTimer during initialization of ddLCMSubscriber

### DIFF
--- a/src/app/ddLCMSubscriber.h
+++ b/src/app/ddLCMSubscriber.h
@@ -35,6 +35,7 @@ public:
     this->mEmitMessages = true;
     this->mNotifyAllMessages = false;
     this->mRequiredElapsedMilliseconds = 0;
+    this->mTimer.start();
     this->connect(this, SIGNAL(messageReceivedInQueue(const QString&)), SLOT(onMessageInQueue(const QString&)));
   }
 


### PR DESCRIPTION
Previously the `mTimer` wasn't being started. If you then called `setSpeedLimit(60)` then the notification would never get passed up to `python` due to the fact that `mTimer.elapsed()` was always equal to zero. So we would get stuck [here](https://github.com/RobotLocomotion/director/blob/master/src/app/ddLCMSubscriber.h#L162). 

I think this bug has been here all along. Probably what happened is that the default behavior changed when we upgraded the Qt version (or it's simply undefined and behaves strangely on 16.04). Anyways I think this PR fixes the issue.

@patmarion 