### PR TITLE
In drake, convexHull.h was renamed to convex_hull.h and moved

### DIFF
--- a/src/app/ddDrakeWrapper.cpp
+++ b/src/app/ddDrakeWrapper.cpp
@@ -10,7 +10,7 @@
 #include <drake/multibody/rigid_body_tree.h>
 #include <drake/multibody/force_torque_measurement.h>
 #endif
-#include <drake/util/convexHull.h>
+#include <drake/systems/robotInterfaces/convex_hull.h>
 
 #include <vector>
 #include <string>


### PR DESCRIPTION
This change happened in drake commit c40f4a04d211934d553e99f0e5a164f4b0f806c5.

The commit message states:
    Move convex_hull from /util to /systems/robotInterfaces

    It's only used from within controllers, and shouldn't be used elsewhere.
    We mark it private, since it's only used from .cc files, also.