### PR TITLE
update sha1 of QtPropertyBrowser used for qt5 build

### DIFF
--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -309,7 +309,7 @@ ExternalProject_Add(ctkPythonConsole
 if(DD_QT_VERSION EQUAL 4)
   set(QtPropertyBrowser_TAG baf10af)
 else()
-  set(QtPropertyBrowser_TAG 5ca603a)
+  set(QtPropertyBrowser_TAG 72a0272)
 endif()
 
 ExternalProject_Add(QtPropertyBrowser


### PR DESCRIPTION
This pulls a version of QtPropertyBrowser where extra
compiler flags like -march-native have been removed.

See:

https://github.com/RobotLocomotion/drake/issues/7740