### PR TITLE
Point cv-utils to a version compatible with libbot as installed by modern Drake

### DIFF
--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -539,8 +539,8 @@ endif()
 if(USE_PERCEPTION)
 
   ExternalProject_Add(cv-utils
-    GIT_REPOSITORY https://github.com/patmarion/cv-utils.git
-    GIT_TAG 9ee0128
+    GIT_REPOSITORY https://github.com/manuelli/cv-utils.git
+    GIT_TAG 26b146fedfe3dcfb47d932911744994b815c4137
     CMAKE_CACHE_ARGS
       ${default_cmake_args}
     DEPENDS

--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -539,8 +539,8 @@ endif()
 if(USE_PERCEPTION)
 
   ExternalProject_Add(cv-utils
-    GIT_REPOSITORY https://github.com/gizatt/cv-utils.git
-    GIT_TAG 3ea4eb1b1b34bb9c9c08ad6627228c04ab6e2f2c
+    GIT_REPOSITORY https://github.com/patmarion/cv-utils.git
+    GIT_TAG c4939fedf66c767de15607adde3aff44ab2b503b
     CMAKE_CACHE_ARGS
       ${default_cmake_args}
     DEPENDS

--- a/distro/superbuild/cmake/externals.cmake
+++ b/distro/superbuild/cmake/externals.cmake
@@ -539,8 +539,8 @@ endif()
 if(USE_PERCEPTION)
 
   ExternalProject_Add(cv-utils
-    GIT_REPOSITORY https://github.com/manuelli/cv-utils.git
-    GIT_TAG 26b146fedfe3dcfb47d932911744994b815c4137
+    GIT_REPOSITORY https://github.com/gizatt/cv-utils.git
+    GIT_TAG 3ea4eb1b1b34bb9c9c08ad6627228c04ab6e2f2c
     CMAKE_CACHE_ARGS
       ${default_cmake_args}
     DEPENDS


### PR DESCRIPTION
(Remove references to the C libbot LCM types.)