### PR TITLE
Make pydrake optional in drakevisualizer.py

### DIFF
--- a/src/python/director/drakevisualizer.py
+++ b/src/python/director/drakevisualizer.py
@@ -24,6 +24,14 @@ import bot_core as lcmbot
 #import robotlocomotion as lcmrl
 lcmrl = lcmbot
 
+# pydrake is only used to provide an additional source of mesh package lookup
+# paths, so failing to find it should not be fatal
+try:
+    import pydrake
+    HAVE_PYDRAKE = True
+except ImportError:
+    HAVE_PYDRAKE = False
+
 from PythonQt import QtGui
 
 class Geometry(object):
@@ -182,9 +190,9 @@ class Geometry(object):
             return filename
 
         if Geometry.PackageMap is None:
-            import pydrake
             m = packagepath.PackageMap()
-            m.populateFromSearchPaths([pydrake.getDrakePath()])
+            if HAVE_PYDRAKE:
+                m.populateFromSearchPaths([pydrake.getDrakePath()])
             m.populateFromEnvironment(['DRAKE_PACKAGE_PATH', 'ROS_PACKAGE_PATH'])
             Geometry.PackageMap = m
 


### PR DESCRIPTION
This makes it possible for future versions of drake to completely remove `drake-visualizer`'s dependency on pydrake. It should be fully backwards compatible (since it just prevents package lookup from crashing if pydrake is not found). 