### PR TITLE
Fix deprecated usages of RigidBodyTree::bodies

### DIFF
--- a/src/app/ddDrakeModel.cpp
+++ b/src/app/ddDrakeModel.cpp
@@ -1259,7 +1259,7 @@ void ddDrakeModel::getModelMeshWithLinkInfoAndNormals(vtkPolyData* polyData)
 
   vtkSmartPointer<vtkAppendPolyData> appendFilter = vtkSmartPointer<vtkAppendPolyData>::New();
 
-  for (const auto & rb: this->Internal->Model->bodies)
+  for (const auto & rb: this->Internal->Model->get_bodies())
   {
     std::string linkNameString = rb->get_name();
     QString linkName = QString::fromStdString(linkNameString);


### PR DESCRIPTION
See https://github.com/robotlocomotion/drake/pull/8085 for more info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/director/595)
<!-- Reviewable:end -->
