### PR TITLE
Searches LCM first using CMake and then using pkgconfig

### DIFF
--- a/cmake/modules/FindLCM.cmake
+++ b/cmake/modules/FindLCM.cmake
@@ -43,9 +43,12 @@ macro(pkg_config_find_module varname pkgname header library pathsuffix)
 endmacro()
 
 
-pkg_config_find_module(LCM lcm lcm/lcm.h lcm lcm)
+find_package(LCM QUIET CONFIG)
+if(NOT LCM_FOUND)
+  pkg_config_find_module(LCM lcm lcm/lcm.h lcm lcm)
 
-if(LCM_STATIC_LIBRARIES)
-  find_package(GLib2)
-  list(APPEND LCM_STATIC_LIBRARIES ${GLib2_LIBRARIES})
+  if(LCM_STATIC_LIBRARIES)
+    find_package(GLib2)
+    list(APPEND LCM_STATIC_LIBRARIES ${GLib2_LIBRARIES})
+  endif()
 endif()


### PR DESCRIPTION
LCM can generate a lcm-config.cmake file which can be used to find
LCM on the system. Instead of requiring LCM to be found with
pkgconfig, this patch modifies director to first search for LCM
using CMake `find_package()` and if this does not work, fall back
on the original implementation using pkgconfig to find the necessary
files.